### PR TITLE
added #include <math.h> for fabs requirement in label_img.cpp

### DIFF
--- a/label_img.cpp
+++ b/label_img.cpp
@@ -1,5 +1,6 @@
 #include "label_img.h"
 #include <QPainter>
+#include <math.h>       /* fabs */
 
 using std::ifstream;
 


### PR DESCRIPTION
Could not get project to compille due to fabs call in label_img.  add the include fixes this for me. 

Ubuntu 19.10