### PR TITLE
Add button to change directory w/ previously loaded objfile; Fix label list not being cleared on file load

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -54,6 +54,19 @@ void MainWindow::on_pushButton_open_files_clicked()
     init();
 }
 
+void MainWindow::on_pushButton_change_dir_clicked()
+{
+    bool bRetImgDir     = false;
+    bool bRetObjFile    = false;
+
+    open_img_dir(bRetImgDir);
+
+    if (!bRetImgDir) return ;
+
+    init();
+}
+
+
 void MainWindow::init()
 {
     ui->label_image->init();
@@ -193,6 +206,7 @@ void MainWindow::load_label_list_data(QString qstrLabelListFile)
 
         m_objList.clear();
 
+        ui->tableWidget_label->setRowCount(0);
         ui->label_image->m_drawObjectBoxColor.clear();
 
         string strLabel;
@@ -417,6 +431,7 @@ void MainWindow::on_horizontalSlider_images_sliderMoved(int position)
 
 void MainWindow::init_button_event()
 {
+    ui->pushButton_change_dir->setEnabled(true);
     ui->pushButton_next->setEnabled(true);
     ui->pushButton_prev->setEnabled(true);
     ui->pushButton_save->setEnabled(true);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -23,6 +23,7 @@ public:
 
 private slots:
     void on_pushButton_open_files_clicked();
+    void on_pushButton_change_dir_clicked();
     void on_pushButton_save_clicked();
     void on_pushButton_remove_clicked();
 

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -378,6 +378,50 @@ border-color: rgb(0, 255, 255);</string>
            </widget>
           </item>
           <item>
+           <widget class="QPushButton" name="pushButton_change_dir">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>200</width>
+              <height>91</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>91</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+              <kerning>true</kerning>
+             </font>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">background-color : rgb(0, 0, 17);color : rgb(0, 255, 255);
+border-style: outset;
+border-width: 2px;
+border-color: rgb(0, 255, 255);</string>
+            </property>
+            <property name="text">
+             <string>Change Directory</string>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+            <property name="default">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QPushButton" name="pushButton_save">
             <property name="enabled">
              <bool>false</bool>
@@ -743,7 +787,7 @@ QTableView {
      <x>0</x>
      <y>0</y>
      <width>1528</width>
-     <height>25</height>
+     <height>23</height>
     </rect>
    </property>
   </widget>


### PR DESCRIPTION
Previously one couldn't load another directory of the same dataset without specifying a list of object names each time. I've added a button to switch dirs, which would save some clicks. Also fixed a problem with the label-color pairs table, which wasn't properly cleared when the user loads another dir (one'd get a bunch of pairs with the same object names but different colors), which also produced inconsistencies between objfile's IDs and label IDs. 