### PR TITLE
Add a shortcut to remove images

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ To minimize wrist strain when labeling, I adopted the method **"twice left butto
 | `W` | Prev Label <br> ![ezgif-5-ee915c66dad8](https://user-images.githubusercontent.com/35001605/47703191-d39d3080-dc62-11e8-800b-986ec214b80c.gif)  |
 | `Ctrl + S` | Save |
 | `Ctrl + C` | Delete all existing bounding boxes in the image |
+| `Ctrl + D` | Delete current image |
 
 | Mouse | Action |
 |---|:---:|

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -29,6 +29,7 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(new QShortcut(QKeySequence(Qt::Key_A), this), SIGNAL(activated()), this, SLOT(prev_img()));
     connect(new QShortcut(QKeySequence(Qt::Key_D), this), SIGNAL(activated()), this, SLOT(next_img()));
     connect(new QShortcut(QKeySequence(Qt::Key_Space), this), SIGNAL(activated()), this, SLOT(next_img()));
+    connect(new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_D), this), SIGNAL(activated()), this, SLOT(remove_img()));
 
     init_table_widget();
 }
@@ -180,6 +181,32 @@ void MainWindow::clear_label_data()
 {
     ui->label_image->m_objBoundingBoxes.clear();
     ui->label_image->showImage();
+}
+
+void MainWindow::remove_img()
+{
+    if(m_imgList.size() > 0) {
+        //remove a image
+        QFile::remove(m_imgList.at(m_imgIndex));
+
+        //remove a txt file
+        QString qstrOutputLabelData = get_labeling_data(m_imgList.at(m_imgIndex));
+        QFile::remove(qstrOutputLabelData);
+
+        m_imgList.removeAt(m_imgIndex);
+
+        if(m_imgList.size() == 0)
+        {
+            pjreddie_style_msgBox(QMessageBox::Information,"End", "In directory, there are not any image. program quit.");
+            QCoreApplication::quit();
+        }
+        else if( m_imgIndex == m_imgList.size())
+        {
+            m_imgIndex --;
+        }
+
+        goto_img(m_imgIndex);
+    }
 }
 
 void MainWindow::next_label()
@@ -377,26 +404,7 @@ void MainWindow::on_pushButton_save_clicked()
 
 void MainWindow::on_pushButton_remove_clicked()
 {
-    //remove a image
-    QFile::remove(m_imgList.at(m_imgIndex));
-
-    //remove a txt file
-    QString qstrOutputLabelData = get_labeling_data(m_imgList.at(m_imgIndex));
-    QFile::remove(qstrOutputLabelData);
-
-    m_imgList.removeAt(m_imgIndex);
-
-    if(m_imgList.size() == 0)
-    {
-        pjreddie_style_msgBox(QMessageBox::Information,"End", "In directory, there are not any image. program quit.");
-        QCoreApplication::quit();
-    }
-    else if( m_imgIndex == m_imgList.size())
-    {
-        m_imgIndex --;
-    }
-
-    goto_img(m_imgIndex);
+    remove_img();
 }
 
 void MainWindow::on_tableWidget_label_cellDoubleClicked(int row, int column)

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -36,6 +36,7 @@ private slots:
     void prev_img(bool bSavePrev = true);
     void save_label_data() const;
     void clear_label_data();
+    void remove_img();
 
     void next_label();
     void prev_label();


### PR DESCRIPTION
While using the program I wanted to quickly remove an image but there was no shortcuts for it. This PR adds **ctrl-d** as a shortcut to remove the current image, but I can change it to something else if you think it is not ideal.