### PR TITLE
Visualize class names on the bounding box

### DIFF
--- a/label_img.cpp
+++ b/label_img.cpp
@@ -269,13 +269,19 @@ void label_img::drawObjectBoxes(QPainter& painter, int thickWidth)
 {
     QPen pen;
     pen.setWidth(thickWidth);
+    QFont font = painter.font();
+    font.setPixelSize(12);
+    font.setBold(true);
+    painter.setFont(font);
 
     for(ObjectLabelingBox boundingbox: m_objBoundingBoxes)
     {
         pen.setColor(m_drawObjectBoxColor.at(boundingbox.label));
         painter.setPen(pen);
 
-        painter.drawRect(cvtRelativeToAbsoluteRectInUi(boundingbox.box));
+        QRect rectUi = cvtRelativeToAbsoluteRectInUi(boundingbox.box);
+        painter.drawRect(rectUi);
+        painter.drawText(rectUi.topLeft() + QPoint(5, 14 + 14 * boundingbox.label), m_objList.at(boundingbox.label));
     }
 }
 

--- a/label_img.cpp
+++ b/label_img.cpp
@@ -80,6 +80,7 @@ void label_img::init()
 {
     m_objBoundingBoxes.clear();
     m_bLabelingStarted              = false;
+    m_bVisualizeClassName           = false;
     m_focusedObjectLabel            = 0;
 
     QPoint mousePosInUi = this->mapFromGlobal(QCursor::pos());
@@ -159,7 +160,7 @@ void label_img::showImage()
 
     QPainter painter(&img);
     QFont font = painter.font();
-    int fontSize = 14, xMargin = 5, yMargin = 2;
+    int fontSize = 16, xMargin = 5, yMargin = 2;
     font.setPixelSize(fontSize);
     font.setBold(true);
     painter.setFont(font);
@@ -171,7 +172,8 @@ void label_img::showImage()
     drawCrossLine(painter, crossLineColor, penThick);
     drawFocusedObjectBox(painter, Qt::magenta, penThick);
     drawObjectBoxes(painter, penThick);
-    drawObjectLabels(painter, penThick, fontSize, xMargin, yMargin);
+    if(m_bVisualizeClassName)
+        drawObjectLabels(painter, penThick, fontSize, xMargin, yMargin);
 
     this->setPixmap(QPixmap::fromImage(img));
 }

--- a/label_img.cpp
+++ b/label_img.cpp
@@ -125,7 +125,8 @@ void label_img::openImage(const QString &qstrImg, bool &ret)
 
         m_inputImg          = img.copy();
         m_inputImg          = m_inputImg.convertToFormat(QImage::Format_RGB888);
-        m_resized_inputImg  = m_inputImg.scaled(this->width(), this->height(),Qt::IgnoreAspectRatio,Qt::SmoothTransformation);
+        m_resized_inputImg  = m_inputImg.scaled(this->width(), this->height(),Qt::IgnoreAspectRatio,Qt::SmoothTransformation)
+                .convertToFormat(QImage::Format_RGB888);
 
         m_bLabelingStarted  = false;
 
@@ -148,7 +149,8 @@ void label_img::showImage()
     if(m_inputImg.isNull()) return;
     if(m_resized_inputImg.width() != this->width() or m_resized_inputImg.height() != this->height())
     {
-        m_resized_inputImg = m_inputImg.scaled(this->width(), this->height(),Qt::IgnoreAspectRatio,Qt::SmoothTransformation);
+        m_resized_inputImg = m_inputImg.scaled(this->width(), this->height(),Qt::IgnoreAspectRatio,Qt::SmoothTransformation)
+                .convertToFormat(QImage::Format_RGB888);
     }
 
     QImage img = m_resized_inputImg;
@@ -156,6 +158,11 @@ void label_img::showImage()
     gammaTransform(img);
 
     QPainter painter(&img);
+    QFont font = painter.font();
+    int fontSize = 14, xMargin = 5, yMargin = 2;
+    font.setPixelSize(fontSize);
+    font.setBold(true);
+    painter.setFont(font);
 
     int penThick = 3;
 
@@ -164,6 +171,7 @@ void label_img::showImage()
     drawCrossLine(painter, crossLineColor, penThick);
     drawFocusedObjectBox(painter, Qt::magenta, penThick);
     drawObjectBoxes(painter, penThick);
+    drawObjectLabels(painter, penThick, fontSize, xMargin, yMargin);
 
     this->setPixmap(QPixmap::fromImage(img));
 }
@@ -269,19 +277,43 @@ void label_img::drawObjectBoxes(QPainter& painter, int thickWidth)
 {
     QPen pen;
     pen.setWidth(thickWidth);
-    QFont font = painter.font();
-    font.setPixelSize(12);
-    font.setBold(true);
-    painter.setFont(font);
 
     for(ObjectLabelingBox boundingbox: m_objBoundingBoxes)
     {
         pen.setColor(m_drawObjectBoxColor.at(boundingbox.label));
         painter.setPen(pen);
 
+        painter.drawRect(cvtRelativeToAbsoluteRectInUi(boundingbox.box));
+    }
+}
+
+void label_img::drawObjectLabels(QPainter& painter, int thickWidth, int fontPixelSize, int xMargin, int yMargin)
+{
+    QFontMetrics fontMetrics = painter.fontMetrics();
+    QPen blackPen;
+
+    for(ObjectLabelingBox boundingbox: m_objBoundingBoxes)
+    {
+        QColor labelColor = m_drawObjectBoxColor.at(boundingbox.label);
         QRect rectUi = cvtRelativeToAbsoluteRectInUi(boundingbox.box);
-        painter.drawRect(rectUi);
-        painter.drawText(rectUi.topLeft() + QPoint(5, 14 + 14 * boundingbox.label), m_objList.at(boundingbox.label));
+
+        QRect labelRect = fontMetrics.boundingRect(m_objList.at(boundingbox.label));
+        if (rectUi.top() > fontPixelSize + yMargin * 2 + thickWidth + 1) {
+            labelRect.moveTo(rectUi.topLeft() + QPoint(-thickWidth / 2, -(fontPixelSize + yMargin * 2 + thickWidth + 1)));
+            labelRect.adjust(0, 0, xMargin * 2, yMargin * 2);
+        } else {
+            labelRect.moveTo(rectUi.topLeft() + QPoint(-thickWidth / 2, 0));
+            labelRect.adjust(0, 0, xMargin * 2, yMargin * 2);
+        }
+        painter.fillRect(labelRect, labelColor);
+
+        if (qGray(m_drawObjectBoxColor.at(boundingbox.label).rgb()) > 120) {
+            blackPen.setColor(QColorConstants::Black);
+        } else {
+            blackPen.setColor(QColorConstants::White);
+        }
+        painter.setPen(blackPen);
+        painter.drawText(labelRect.topLeft() + QPoint(xMargin, yMargin + fontPixelSize), m_objList.at(boundingbox.label));
     }
 }
 

--- a/label_img.h
+++ b/label_img.h
@@ -34,6 +34,7 @@ public:
     int m_imgY;
 
     bool m_bLabelingStarted;
+    bool m_bVisualizeClassName;
 
     static  QColor BOX_COLORS[10];
 

--- a/label_img.h
+++ b/label_img.h
@@ -87,6 +87,7 @@ private:
     void drawCrossLine(QPainter& , QColor , int thickWidth = 3);
     void drawFocusedObjectBox(QPainter& , Qt::GlobalColor , int thickWidth = 3);
     void drawObjectBoxes(QPainter& , int thickWidth = 3);
+    void drawObjectLabels(QPainter& , int thickWidth = 3, int fontPixelSize = 14, int xMargin = 5, int yMargin = 2);
     void gammaTransform(QImage& image);
     void removeFocusedObjectBox(QPointF);
 };

--- a/label_img.h
+++ b/label_img.h
@@ -25,6 +25,7 @@ public:
     void mouseReleaseEvent(QMouseEvent *ev);
 
     QVector<QColor> m_drawObjectBoxColor;
+    QStringList     m_objList;
 
     int m_uiX;
     int m_uiY;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -198,7 +198,7 @@ void MainWindow::remove_img()
         }
         else if( m_imgIndex == m_imgList.size())
         {
-            m_imgIndex --;
+            m_imgIndex--;
         }
 
         goto_img(m_imgIndex);
@@ -361,11 +361,6 @@ void MainWindow::open_obj_file(bool& ret)
     }
 }
 
-void MainWindow::reupdate_img_list()
-{
-
-}
-
 void MainWindow::wheelEvent(QWheelEvent *ev)
 {
     if(ev->angleDelta().y() > 0) // up Wheel
@@ -479,4 +474,10 @@ void MainWindow::on_horizontalSlider_contrast_sliderMoved(int value)
 
     ui->label_image->setContrastGamma(percentageToGamma);
     ui->label_contrast->setText(QString("Contrast(%) ") + QString::number(int(valueToPercentage * 100.)));
+}
+
+void MainWindow::on_checkBox_visualize_class_name_clicked(bool checked)
+{
+    ui->label_image->m_bVisualizeClassName = checked;
+    ui->label_image->showImage();
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -250,6 +250,7 @@ void MainWindow::load_label_list_data(QString qstrLabelListFile)
 
             ui->label_image->m_drawObjectBoxColor.push_back(labelColor);
         }
+        ui->label_image->m_objList = m_objList;
     }
 }
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -23,10 +23,6 @@ public:
 
 private slots:
     void on_pushButton_open_files_clicked();
-//    void on_pushButton_change_dir_clicked();
-//    void on_pushButton_save_clicked();
-//    void on_pushButton_remove_clicked();
-
     void on_pushButton_prev_clicked();
     void on_pushButton_next_clicked();
 
@@ -47,6 +43,8 @@ private slots:
     void on_horizontalSlider_images_sliderMoved(int );
 
     void on_horizontalSlider_contrast_sliderMoved(int value);
+
+    void on_checkBox_visualize_class_name_clicked(bool checked);
 
 private:
     void            init();
@@ -70,8 +68,6 @@ private:
 
     void            open_img_dir(bool&);
     void            open_obj_file(bool&);
-
-    void            reupdate_img_list();
 
     Ui::MainWindow *ui;
 

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -57,7 +57,7 @@
     </size>
    </property>
    <layout class="QGridLayout" name="gridLayout">
-    <item row="0" column="0">
+    <item row="3" column="0">
      <layout class="QHBoxLayout" name="horizontalLayout_5">
       <item>
        <layout class="QVBoxLayout" name="verticalLayout">
@@ -77,6 +77,7 @@
           </property>
           <property name="font">
            <font>
+            <family>Arial</family>
             <pointsize>18</pointsize>
             <weight>75</weight>
             <bold>true</bold>
@@ -106,7 +107,7 @@ border-color: rgb(0, 255, 255);}
            <number>3</number>
           </property>
           <property name="text">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open a Dataset Directory...&lt;/p&gt;&lt;p&gt;D: Next Image&lt;/p&gt;&lt;p&gt;A: Prev Image&lt;/p&gt;&lt;p&gt;&lt;br/&gt;Ctrl + S: Save&lt;/p&gt;&lt;p&gt;Ctrl + D: Delete an Image&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open a Dataset Directory...&lt;/p&gt;&lt;p&gt;D: Next Image&lt;/p&gt;&lt;p&gt;A: Prev Image&lt;/p&gt;&lt;p&gt;S: Next Class&lt;/p&gt;&lt;p&gt;W: Prev Class&lt;/p&gt;&lt;p&gt;V: Visualize Class Name&lt;br/&gt;Ctrl + S: Save&lt;/p&gt;&lt;p&gt;Ctrl + D: Delete an Image&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="scaledContents">
            <bool>true</bool>
@@ -571,6 +572,32 @@ QTableView {
           <string>Color</string>
          </property>
         </column>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item row="0" column="0">
+     <layout class="QHBoxLayout" name="horizontalLayout_6">
+      <item>
+       <widget class="QCheckBox" name="checkBox_visualize_class_names">
+        <property name="font">
+         <font>
+          <family>Arial</family>
+          <pointsize>12</pointsize>
+          <underline>false</underline>
+          <strikeout>false</strikeout>
+         </font>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">background-color : rgb(0, 0, 17);color : rgb(0, 255, 255);
+</string>
+        </property>
+        <property name="text">
+         <string>Visualize Class Names</string>
+        </property>
+        <property name="shortcut">
+         <string>V</string>
+        </property>
        </widget>
       </item>
      </layout>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -107,7 +107,7 @@ border-color: rgb(0, 255, 255);}
            <number>3</number>
           </property>
           <property name="text">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open a Dataset Directory...&lt;/p&gt;&lt;p&gt;D: Next Image&lt;/p&gt;&lt;p&gt;A: Prev Image&lt;/p&gt;&lt;p&gt;S: Next Class&lt;/p&gt;&lt;p&gt;W: Prev Class&lt;/p&gt;&lt;p&gt;V: Visualize Class Name&lt;br/&gt;Ctrl + S: Save&lt;/p&gt;&lt;p&gt;Ctrl + D: Delete an Image&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open a Dataset Directory...&lt;/p&gt;&lt;p&gt;D: Next Image&lt;/p&gt;&lt;p&gt;A: Prev Image&lt;/p&gt;&lt;p&gt;S: Next Class&lt;/p&gt;&lt;p&gt;W: Prev Class&lt;/p&gt;&lt;p&gt;V: Visualize Class Name&lt;/p&gt;&lt;p&gt;O: Open Files&lt;br/&gt;Ctrl + S: Save&lt;/p&gt;&lt;p&gt;Ctrl + D: Delete an Image&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="scaledContents">
            <bool>true</bool>
@@ -397,6 +397,9 @@ border-color: rgb(0, 255, 255);</string>
             <property name="text">
              <string>Open Files</string>
             </property>
+            <property name="shortcut">
+             <string>O</string>
+            </property>
             <property name="autoDefault">
              <bool>false</bool>
             </property>
@@ -579,7 +582,7 @@ QTableView {
     <item row="0" column="0">
      <layout class="QHBoxLayout" name="horizontalLayout_6">
       <item>
-       <widget class="QCheckBox" name="checkBox_visualize_class_names">
+       <widget class="QCheckBox" name="checkBox_visualize_class_name">
         <property name="font">
          <font>
           <family>Arial</family>
@@ -593,7 +596,7 @@ QTableView {
 </string>
         </property>
         <property name="text">
-         <string>Visualize Class Names</string>
+         <string>Visualize Class Name</string>
         </property>
         <property name="shortcut">
          <string>V</string>


### PR DESCRIPTION
I also need class names on the bounding box, just like #43 says.
So I try my best to made one, and mimic the "Darknet style". Hope you like it. 😊

By the way, I found `QImage::scaled()` returned an image with different format. It returned an image with `QImage::Format_RGB32` format, then gamma transform would not work perfectly. I has fixed this problem.

These function has been tested on my Manjaro Linux, with Qt 5.15.6