### PR TITLE
fix: resolve undo/redo issues from PR #77

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ To minimize wrist strain when labeling, I adopted the method **"twice left butto
 | `Ctrl + S` | Save |
 | `Ctrl + C` | Delete all existing bounding boxes in the image |
 | `Ctrl + D` | Delete current image |
-| `Ctrl + Z` (Windows/Linux) / `Cmd + Z` (macOS) | Undo last action (add, remove, or label change) |
+| `Ctrl + Z` (Windows/Linux) / `Cmd + Z` (macOS) | Undo last action (add, remove, or clear all) |
+| `Ctrl + Shift + Z` (Windows/Linux) / `Cmd + Shift + Z` (macOS) | Redo last undone action |
 
 | Mouse | Action |
 |---|:---:|

--- a/label_img.cpp
+++ b/label_img.cpp
@@ -183,7 +183,6 @@ void label_img::showImage()
 
 void label_img::loadLabelData(const QString& labelFilePath)
 {
-    clearUndoHistory();
     ifstream inputFile(qPrintable(labelFilePath));
 
     if(inputFile.is_open())
@@ -374,8 +373,16 @@ void label_img::removeFocusedObjectBox(QPointF point)
     }
 }
 
+void label_img::clearAllBoxes()
+{
+    saveState();
+    m_objBoundingBoxes.clear();
+}
+
 void label_img::saveState()
 {
+    if(m_undoHistory.size() >= MAX_UNDO_HISTORY)
+        m_undoHistory.removeFirst();
     m_undoHistory.append(m_objBoundingBoxes);
     m_redoHistory.clear();
 }

--- a/label_img.h
+++ b/label_img.h
@@ -24,8 +24,6 @@ public:
     void mousePressEvent(QMouseEvent *ev);
     void mouseReleaseEvent(QMouseEvent *ev);
 
-    void setFocusedObjectBoxLabel(QPointF point, int newLabel);
-
     QVector<QColor> m_drawObjectBoxColor;
     QStringList     m_objList;
 
@@ -54,6 +52,7 @@ public:
 
     bool isOpened();
 
+    void clearAllBoxes();
     void saveState();
     bool undo();
     bool redo();
@@ -91,6 +90,7 @@ private:
     unsigned char m_gammatransform_lut[256];
     QVector<QRgb> colorTable;
 
+    static const int MAX_UNDO_HISTORY = 50;
     QVector< QVector<ObjectLabelingBox> > m_undoHistory;
     QVector< QVector<ObjectLabelingBox> > m_redoHistory;
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -6,8 +6,6 @@
 #include <QKeyEvent>
 #include <QDebug>
 #include <QShortcut>
-#include <QApplication>
-#include <QEvent>
 #include <QCollator>
 #include <iomanip>
 #include <cmath>
@@ -40,8 +38,6 @@ MainWindow::MainWindow(QWidget *parent) :
 
     QShortcut *redoShortcut = new QShortcut(QKeySequence::Redo, this, SLOT(redo()));
     redoShortcut->setContext(Qt::ApplicationShortcut);
-
-    qApp->installEventFilter(this);
 
     init_table_widget();
 }
@@ -126,6 +122,7 @@ void MainWindow::goto_img(const int fileIndex)
     bool bImgOpened;
     ui->label_image->openImage(m_imgList.at(m_imgIndex), bImgOpened);
 
+    ui->label_image->clearUndoHistory();
     ui->label_image->loadLabelData(get_labeling_data(m_imgList.at(m_imgIndex)));
     ui->label_image->showImage();
 
@@ -185,8 +182,7 @@ void MainWindow::save_label_data()
 
 void MainWindow::clear_label_data()
 {
-    ui->label_image->saveState();
-    ui->label_image->m_objBoundingBoxes.clear();
+    ui->label_image->clearAllBoxes();
     ui->label_image->showImage();
 }
 
@@ -378,25 +374,6 @@ void MainWindow::wheelEvent(QWheelEvent *ev)
         prev_img();
     else if(ev->angleDelta().y() < 0) //down Wheel
         next_img();
-}
-
-bool MainWindow::eventFilter(QObject *watched, QEvent *event)
-{
-    if(event->type() == QEvent::KeyPress)
-    {
-        QKeyEvent *ke = static_cast<QKeyEvent *>(event);
-        if(ke->key() == Qt::Key_Z && ke->modifiers() == Qt::ControlModifier)
-        {
-            undo();
-            return true;
-        }
-        if(ke->key() == Qt::Key_Z && ke->modifiers() == (Qt::ControlModifier | Qt::ShiftModifier))
-        {
-            redo();
-            return true;
-        }
-    }
-    return QMainWindow::eventFilter(watched, event);
 }
 
 void MainWindow::on_pushButton_prev_clicked()

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -85,7 +85,6 @@ private:
 
 protected:
     void    wheelEvent(QWheelEvent *);
-    bool    eventFilter(QObject *watched, QEvent *event) override;
 };
 
 #endif // MAINWINDOW_H


### PR DESCRIPTION
## Summary

Fixes issues found in PR #77 (`feature/undo`):

- **Remove duplicate shortcut registration**: `eventFilter` and `QShortcut` both handled Ctrl+Z/Ctrl+Shift+Z, causing undo/redo to fire twice per keypress. Removed `eventFilter`, keeping the cleaner `QShortcut` approach.
- **Remove unimplemented `setFocusedObjectBoxLabel` declaration**: The method was declared in `label_img.h` but never implemented, causing a linker error.
- **Add undo history memory limit**: Capped `m_undoHistory` to 50 entries (`MAX_UNDO_HISTORY`) to prevent unbounded memory growth during long labeling sessions.
- **Move `clearUndoHistory()` to navigation level**: Moved from `loadLabelData()` to `goto_img()` in `mainwindow.cpp` so the per-image undo scope is explicit and not dependent on `loadLabelData` internals.
- **Encapsulate box clearing**: Added `label_img::clearAllBoxes()` method instead of directly accessing `m_objBoundingBoxes` from `MainWindow::clear_label_data()`.
- **Add redo shortcut to README**: Documented `Ctrl+Shift+Z` / `Cmd+Shift+Z` and corrected the undo description (removed "label change" which was not implemented).

## Test plan

- [ ] Verify Ctrl+Z undoes only once per keypress (not twice)
- [ ] Verify Ctrl+Shift+Z redoes correctly
- [ ] Verify undo history is cleared when navigating between images
- [ ] Verify Ctrl+C (clear all boxes) is undoable
- [ ] Build succeeds without linker errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)