### PR TITLE
feat: add Ctrl+V to paste annotations from previous image

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ To minimize wrist strain when labeling, I adopted the method **"twice left butto
 | `V` | Visualize Class Name |
 | `Ctrl + S` | Save |
 | `Ctrl + C` | Delete all existing bounding boxes in the image |
+| `Ctrl + V` | Paste annotations from the previous image to the current image |
 | `Ctrl + D` | Delete current image |
 
 | Mouse | Action |

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -32,6 +32,7 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(new QShortcut(QKeySequence(Qt::Key_Space), this), SIGNAL(activated()), this, SLOT(next_img()));
     connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_D), this), SIGNAL(activated()), this, SLOT(remove_img()));
     connect(new QShortcut(QKeySequence(Qt::Key_Delete), this), SIGNAL(activated()), this, SLOT(remove_img()));
+    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_V), this), SIGNAL(activated()), this, SLOT(paste_previous_annotations()));
 
     init_table_widget();
 }
@@ -110,6 +111,9 @@ void MainWindow::goto_img(const int fileIndex)
 {
     bool bIndexIsOutOfRange = (fileIndex < 0 || fileIndex > m_imgList.size() - 1);
     if (bIndexIsOutOfRange) return;
+
+    if (ui->label_image->isOpened())
+        m_previousAnnotations = ui->label_image->m_objBoundingBoxes;
 
     m_imgIndex = fileIndex;
 
@@ -479,5 +483,12 @@ void MainWindow::on_horizontalSlider_contrast_sliderMoved(int value)
 void MainWindow::on_checkBox_visualize_class_name_clicked(bool checked)
 {
     ui->label_image->m_bVisualizeClassName = checked;
+    ui->label_image->showImage();
+}
+
+void MainWindow::paste_previous_annotations()
+{
+    if (m_previousAnnotations.isEmpty() || !ui->label_image->isOpened()) return;
+    ui->label_image->m_objBoundingBoxes = m_previousAnnotations;
     ui->label_image->showImage();
 }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -9,6 +9,8 @@
 #include <iostream>
 #include <fstream>
 
+#include "label_img.h"
+
 namespace Ui {
 class MainWindow;
 }
@@ -46,6 +48,8 @@ private slots:
 
     void on_checkBox_visualize_class_name_clicked(bool checked);
 
+    void paste_previous_annotations();
+
 private:
     void            init();
     void            init_table_widget();
@@ -79,6 +83,8 @@ private:
     int             m_objIndex;
     int             m_lastDeletedImgIndex;
     int             m_lastLabeledImgIndex;
+
+    QVector<ObjectLabelingBox> m_previousAnnotations;
 
 protected:
     void    wheelEvent(QWheelEvent *);


### PR DESCRIPTION
## Summary
- Adds **Ctrl+V** shortcut to paste annotations from the previous image onto the current image
- Captures current annotations in `goto_img()` before switching, so `m_previousAnnotations` stays up-to-date regardless of navigation method (A/D keys, slider, wheel, remove)
- Does nothing gracefully when there are no previous annotations or no image is open

## Files Changed
- `mainwindow.h` — added `#include "label_img.h"`, `m_previousAnnotations` member, `paste_previous_annotations()` slot
- `mainwindow.cpp` — added shortcut connection, annotation capture in `goto_img()`, paste slot implementation
- `README.md` — added `Ctrl + V` row to shortcuts table

## Test plan
- [ ] Build the project with qmake + make
- [ ] Open a dataset with multiple images
- [ ] Label image 0, press D to go to image 1, press Ctrl+V → annotations from image 0 should appear
- [ ] Navigate via slider to image 5, press Ctrl+V → annotations from image 4 should appear (not stale)
- [ ] Press Ctrl+V on first image with no previous → nothing should happen

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)