### PR TITLE
Add PR description review rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ Key design: uses a **two-click method** (not drag-and-drop) to define bounding b
 - Each branch should contain a single, focused unit of work
 - Do not start a new task on the same branch — create a new branch for each task
 - **When working on an existing PR** (e.g., fixing issues, adding changes), push commits directly to that PR's branch instead of creating a new PR. Only create a separate PR if explicitly requested. For cross-repository (fork) PRs, add the contributor's fork as a remote (e.g., `git remote add <user> <fork-url>`) and push to that remote's branch.
+- **Before merging a PR**, review its description. If the body is empty or lacks sufficient detail (e.g., no explanation of what changed or why), rewrite it using `gh pr edit <number> --body "..."`. A good PR description should include: a summary of what the PR does and why, a list of key changes, and any relevant context (e.g., related issues, shortcuts added, behavioral changes). Look at the actual commits and code diff to write an accurate description.
 - **Before merging a PR**, check if `master` has advanced since the PR was created. If so, check for conflicts (e.g., `git merge-tree`) and rebase or merge `master` into the PR branch to resolve them before merging.
 - **Never use `git checkout` or `git switch` to change branches.** Use `git worktree` to work on multiple branches simultaneously in separate directories
   - Create a worktree: `git worktree add ../Yolo_Label-<branch-name> -b <type>/<short-description>`


### PR DESCRIPTION
## Summary
- Add a rule to CLAUDE.md requiring PR descriptions to be reviewed before merging
- If a PR body is empty or insufficient, it should be rewritten with a proper summary, key changes, and context based on the actual commits and diff

## Context
Some external PRs (e.g., #79) have been submitted with completely empty descriptions. This rule ensures all PRs have meaningful documentation before being merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)