### PR TITLE
ci: skip builds for non-source file changes

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -4,8 +4,20 @@ on:
   push:
     branches: [master]
     tags: ['v*']
+    paths-ignore:
+      - '**.md'
+      - '.claude/**'
+      - '.gitignore'
+      - 'LICENSE'
+      - 'Samples/**'
   pull_request:
     branches: [master]
+    paths-ignore:
+      - '**.md'
+      - '.claude/**'
+      - '.gitignore'
+      - 'LICENSE'
+      - 'Samples/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Add `paths-ignore` filters to both `push` and `pull_request` triggers in CI workflow
- CI will no longer run when only non-source files change (e.g., docs, config, samples)

## Ignored paths
- `**.md` — all Markdown files
- `.claude/**` — Claude configuration
- `.gitignore` — git ignore rules
- `LICENSE` — license file
- `Samples/**` — sample data

## Why
Avoids wasting CI build minutes on changes that cannot affect the compiled application (Qt/C++ source unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)