### PR TITLE
fix: add ad-hoc code signing for macOS build

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -106,8 +106,9 @@ jobs:
       - name: Package (macOS)
         if: runner.os == 'macOS'
         run: |
-          macdeployqt YoloLabel.app -dmg
-          mv YoloLabel.dmg "${{ matrix.artifact_name }}.dmg"
+          macdeployqt YoloLabel.app
+          codesign --force --deep --sign - YoloLabel.app
+          hdiutil create -volname YoloLabel -srcfolder YoloLabel.app -ov -format UDZO "${{ matrix.artifact_name }}.dmg"
 
       # ── Package: Linux ────────────────────────────────────────
       - name: Package (Linux)


### PR DESCRIPTION
## Summary
macOS Gatekeeper marks unsigned apps downloaded from the internet as "damaged" and refuses to open them. This PR adds ad-hoc code signing (`codesign --force --deep --sign -`) after `macdeployqt` to resolve this issue.

## Key changes
- Run `macdeployqt` without `-dmg` flag so we can sign the `.app` bundle first
- Add `codesign --force --deep --sign -` to ad-hoc sign the app bundle
- Use `hdiutil` to create the DMG after signing

## Note
Ad-hoc signing does not require an Apple Developer certificate. Users may still need to right-click → Open on first launch, but they will no longer see the "damaged" error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)