### PR TITLE
feat: add Landing AI integration for cloud auto-labeling

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -139,6 +139,10 @@ jobs:
           ./test_yolo_detector
           make clean
 
+          qmake test_landing_ai_parser.pro && make -j$NPROC
+          ./test_landing_ai_parser
+          make clean
+
       - name: Build and run unit tests (Windows)
         if: runner.os == 'Windows'
         shell: cmd
@@ -160,6 +164,11 @@ jobs:
           qmake test_yolo_detector.pro "ONNXRUNTIME_DIR=%CD%\..\onnxruntime"
           nmake
           release\test_yolo_detector.exe
+          nmake clean
+
+          qmake test_landing_ai_parser.pro
+          nmake
+          release\test_landing_ai_parser.exe
           nmake clean
 
       # ── Accuracy Test (Linux only) ────────────────────────────

--- a/cloud_labeler.cpp
+++ b/cloud_labeler.cpp
@@ -738,13 +738,18 @@ QStringList CloudAutoLabeler::parseLandingAIDetections(const QJsonArray &detecti
         double x1 = bb[0].toDouble(), y1 = bb[1].toDouble();
         double x2 = bb[2].toDouble(), y2 = bb[3].toDouble();
 
+        // Clamp corners to image bounds so partially off-image boxes are usable
+        x1 = qMax(0.0, qMin(x1, imgW));
+        y1 = qMax(0.0, qMin(y1, imgH));
+        x2 = qMax(0.0, qMin(x2, imgW));
+        y2 = qMax(0.0, qMin(y2, imgH));
+
         double cx = ((x1 + x2) / 2.0) / imgW;
         double cy = ((y1 + y2) / 2.0) / imgH;
         double nw = (x2 - x1) / imgW;
         double nh = (y2 - y1) / imgH;
 
-        if (cx < 0.0 || cx > 1.0 || cy < 0.0 || cy > 1.0 ||
-            nw <= 0.0 || nw > 1.0 || nh <= 0.0 || nh > 1.0) continue;
+        if (nw <= 0.0 || nh <= 0.0) continue;
 
         outputLines << QString("%1 %2 %3 %4 %5")
             .arg(classId)

--- a/cloud_labeler.cpp
+++ b/cloud_labeler.cpp
@@ -705,3 +705,56 @@ void CloudAutoLabeler::fetchBatchResults(int idx, int retryCount)
         fetchBatchResults(idx + 1);
     });
 }
+
+// ── Landing AI response parser ───────────────────────────────────────────────
+
+QStringList CloudAutoLabeler::parseLandingAIDetections(const QJsonArray &detections,
+                                                        const QStringList &objList,
+                                                        double imgW, double imgH,
+                                                        QStringList *skipped)
+{
+    QStringList outputLines;
+    for (const QJsonValue &v : detections) {
+        if (!v.isObject()) continue;
+        QJsonObject obj = v.toObject();
+        QString label   = obj.value("label").toString();
+
+        int classId = objList.indexOf(label);
+        if (classId < 0) {
+            // Case-insensitive fallback
+            for (int i = 0; i < objList.size(); ++i) {
+                if (objList[i].compare(label, Qt::CaseInsensitive) == 0) {
+                    classId = i; break;
+                }
+            }
+        }
+        if (classId < 0) {
+            if (skipped && !label.isEmpty() && !skipped->contains(label))
+                *skipped << label;
+            continue;
+        }
+
+        QJsonArray bb = obj.value("bounding_box").toArray();
+        if (bb.size() < 4) continue;
+        if (!bb[0].isDouble() || !bb[1].isDouble() ||
+            !bb[2].isDouble() || !bb[3].isDouble()) continue;
+        double x1 = bb[0].toDouble(), y1 = bb[1].toDouble();
+        double x2 = bb[2].toDouble(), y2 = bb[3].toDouble();
+
+        double cx = ((x1 + x2) / 2.0) / imgW;
+        double cy = ((y1 + y2) / 2.0) / imgH;
+        double nw = (x2 - x1) / imgW;
+        double nh = (y2 - y1) / imgH;
+
+        if (cx < 0.0 || cx > 1.0 || cy < 0.0 || cy > 1.0 ||
+            nw <= 0.0 || nw > 1.0 || nh <= 0.0 || nh > 1.0) continue;
+
+        outputLines << QString("%1 %2 %3 %4 %5")
+            .arg(classId)
+            .arg(QString::number(cx, 'f', 6))
+            .arg(QString::number(cy, 'f', 6))
+            .arg(QString::number(nw, 'f', 6))
+            .arg(QString::number(nh, 'f', 6));
+    }
+    return outputLines;
+}

--- a/cloud_labeler.cpp
+++ b/cloud_labeler.cpp
@@ -717,15 +717,12 @@ QStringList CloudAutoLabeler::parseLandingAIDetections(const QJsonArray &detecti
     for (const QJsonValue &v : detections) {
         if (!v.isObject()) continue;
         QJsonObject obj = v.toObject();
-        QString label   = obj.value("label").toString();
+        QString label   = obj.value("label").toString().trimmed();
 
-        int classId = objList.indexOf(label);
-        if (classId < 0) {
-            // Case-insensitive fallback
-            for (int i = 0; i < objList.size(); ++i) {
-                if (objList[i].compare(label, Qt::CaseInsensitive) == 0) {
-                    classId = i; break;
-                }
+        int classId = -1;
+        for (int i = 0; i < objList.size(); ++i) {
+            if (objList[i].trimmed().compare(label, Qt::CaseInsensitive) == 0) {
+                classId = i; break;
             }
         }
         if (classId < 0) {

--- a/cloud_labeler.h
+++ b/cloud_labeler.h
@@ -38,6 +38,10 @@ public:
     void labelImages(const QStringList &imagePaths);    // batch (all images)
     void cancel();
 
+    // Utilities used by MainWindow
+    static QString mimeForImage(const QString &path);
+    static void    backupLabelFile(const QString &labelPath);
+
 signals:
     // Emitted when a label file has been written for one image.
     void labelReady(const QString &imagePath, int nDetections, int computeMs);
@@ -69,8 +73,6 @@ private:
     void processNextInQueue();
     void handleFatalError(const QString &message);
 
-    static QString  mimeForImage(const QString &path);
-    static void     backupLabelFile(const QString &labelPath);
     static QString  labelPathFor(const QString &imagePath);
     static QString  filterValidDetections(const QString &yoloTxt, int numClasses);
     static QString  remapWithClassNames(const QString &yoloTxt,

--- a/cloud_labeler.h
+++ b/cloud_labeler.h
@@ -39,8 +39,14 @@ public:
     void cancel();
 
     // Utilities used by MainWindow
-    static QString mimeForImage(const QString &path);
-    static void    backupLabelFile(const QString &labelPath);
+    static QString     mimeForImage(const QString &path);
+    static void        backupLabelFile(const QString &labelPath);
+    // Parse a Landing AI detections JSON array into YOLO annotation lines.
+    // Pure function — no network or file I/O; used by MainWindow and unit tests.
+    static QStringList parseLandingAIDetections(const QJsonArray &detections,
+                                                const QStringList &objList,
+                                                double imgW, double imgH,
+                                                QStringList *skipped = nullptr);
 
 signals:
     // Emitted when a label file has been written for one image.

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1679,10 +1679,21 @@ void MainWindow::landingAIAutoLabelAll()
 
     if (!checkLandingConsent()) return;
 
+    // Estimate total upload size and warn if large
+    qint64 totalBytes = 0;
+    for (const QString &path : m_imgList)
+        totalBytes += QFileInfo(path).size();
+    QString confirmMsg = QString("Send all %1 images to Landing AI?\nExisting labels will be overwritten.")
+        .arg(m_imgList.size());
+    constexpr qint64 warnThresholdMB = 500;
+    if (totalBytes > warnThresholdMB * 1024 * 1024) {
+        confirmMsg += QString("\n\nWarning: estimated upload size is ~%1 MB. "
+                              "This may take a while and use significant bandwidth.")
+            .arg(totalBytes / (1024 * 1024));
+    }
+
     QMessageBox msgBox(QMessageBox::Question, "Landing AI All",
-        QString("Send all %1 images to Landing AI?\nExisting labels will be overwritten.")
-            .arg(m_imgList.size()),
-        QMessageBox::Yes | QMessageBox::No, this);
+        confirmMsg, QMessageBox::Yes | QMessageBox::No, this);
     if (msgBox.exec() != QMessageBox::Yes) return;
 
     save_label_data();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1315,7 +1315,8 @@ void MainWindow::cancelAutoLabel()
     }
     m_landingCancelled = true;
     m_landingQueue.clear();
-    m_cloudLabeler->cancel();
+    if (m_cloudLabeler->isBusy())
+        m_cloudLabeler->cancel();
     resetCloudButtons();  // always reset — busyChanged may not fire when CloudAutoLabeler is already idle
 }
 
@@ -1501,15 +1502,11 @@ void MainWindow::doLandingAIJob(const QString &imagePath, int retryCount, int ge
     imgPart.setBodyDevice(imgFile);
     multiPart->append(imgPart);
 
-    for (const QString &p : m_batchLandingPrompt.split(";")) {
-        const QString label = p.trimmed();
-        if (label.isEmpty()) continue;
-        QHttpPart promptsPart;
-        promptsPart.setHeader(QNetworkRequest::ContentDispositionHeader,
-                              "form-data; name=\"prompts\"");
-        promptsPart.setBody(label.toUtf8());
-        multiPart->append(promptsPart);
-    }
+    QHttpPart promptsPart;
+    promptsPart.setHeader(QNetworkRequest::ContentDispositionHeader,
+                          "form-data; name=\"prompts\"");
+    promptsPart.setBody(m_batchLandingPrompt.toUtf8());
+    multiPart->append(promptsPart);
 
     QHttpPart modelPart;
     modelPart.setHeader(QNetworkRequest::ContentDispositionHeader,
@@ -1561,15 +1558,16 @@ void MainWindow::doLandingAIJob(const QString &imagePath, int retryCount, int ge
         }
 
         // Response: {"data": [[{label, score, bounding_box:[x1,y1,x2,y2]}, ...], ...]}
+        // data may be null (no detections) or an array.
         QJsonValue dataVal = doc.object().value("data");
-        if (!dataVal.isArray()) {
+        if (!dataVal.isArray() && !dataVal.isNull()) {
             // Malformed or error response (e.g. {"error":"quota exceeded"})
             QMessageBox::warning(this, "Landing AI", "Unexpected response from server.");
             m_landingQueue.clear();
             resetCloudButtons();
             return;
         }
-        if (dataVal.toArray().isEmpty()) {
+        if (dataVal.isNull() || dataVal.toArray().isEmpty()) {
             // Server returned no detections — preserve existing label file
             if (m_landingQueue.isEmpty()) {
                 goto_img(m_imgIndex);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1562,7 +1562,14 @@ void MainWindow::doLandingAIJob(const QString &imagePath, int retryCount, int ge
 
         // Response: {"data": [[{label, score, bounding_box:[x1,y1,x2,y2]}, ...], ...]}
         QJsonValue dataVal = doc.object().value("data");
-        if (!dataVal.isArray() || dataVal.toArray().isEmpty()) {
+        if (!dataVal.isArray()) {
+            // Malformed or error response (e.g. {"error":"quota exceeded"})
+            QMessageBox::warning(this, "Landing AI", "Unexpected response from server.");
+            m_landingQueue.clear();
+            resetCloudButtons();
+            return;
+        }
+        if (dataVal.toArray().isEmpty()) {
             // Server returned no detections — preserve existing label file
             if (m_landingQueue.isEmpty()) {
                 goto_img(m_imgIndex);
@@ -1592,6 +1599,7 @@ void MainWindow::doLandingAIJob(const QString &imagePath, int retryCount, int ge
         double imgH = imgSize.height();
 
         if (imgW <= 0 || imgH <= 0) {
+            ++m_landingFailCount;
             statusBar()->showMessage(
                 "Landing AI: could not read image dimensions: " + imagePath, 5000);
             if (m_landingQueue.isEmpty()) resetCloudButtons();
@@ -1616,6 +1624,7 @@ void MainWindow::doLandingAIJob(const QString &imagePath, int retryCount, int ge
                     out << line << "\n";
                 lf.close();
             } else {
+                ++m_landingFailCount;
                 statusBar()->showMessage(
                     "Landing AI: could not write label file: " + labelPath, 5000);
                 if (m_landingQueue.isEmpty())
@@ -1692,6 +1701,7 @@ void MainWindow::landingAIAutoLabelAll()
     m_landingCancelled = false;
     m_landingBusy = true;
     ++m_landingGeneration;
+    m_landingFailCount = 0;
     m_landingQueue.clear();
     for (int i = 0; i < m_imgList.size(); ++i)
         m_landingQueue.append(i);
@@ -1710,8 +1720,14 @@ void MainWindow::landingAIProcessNextInQueue()
 {
     if (m_landingQueue.isEmpty()) {
         goto_img(m_imgIndex);
-        statusBar()->showMessage(
-            QString("Landing AI: all %1 images done.").arg(m_imgList.size()), 5000);
+        int total    = m_imgList.size();
+        int failed   = m_landingFailCount;
+        int succeeded = total - failed;
+        QString msg = failed > 0
+            ? QString("Landing AI: %1/%2 images labeled (%3 failed).")
+                  .arg(succeeded).arg(total).arg(failed)
+            : QString("Landing AI: all %1 images done.").arg(total);
+        statusBar()->showMessage(msg, 5000);
         resetCloudButtons();
         return;
     }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -201,6 +201,7 @@ MainWindow::MainWindow(QWidget *parent) :
     m_btnCloudAutoLabel->setToolTip("Label current image using cloud AI");
     m_btnCloudAutoLabel->setStyleSheet(cloudBtnStyle);
     connect(m_btnCloudAutoLabel, &QPushButton::clicked, this, [this](){
+        if (m_landingBusy || (m_cloudLabeler && m_cloudLabeler->isBusy())) return;
         if (m_modelCombo->currentIndex() == ProviderLandingAI) submitLandingAIJob();
         else                                                    submitCloudJob();
     });
@@ -209,6 +210,7 @@ MainWindow::MainWindow(QWidget *parent) :
     m_btnCloudAutoLabelAll->setToolTip("Label all images using cloud AI");
     m_btnCloudAutoLabelAll->setStyleSheet(cloudBtnStyle);
     connect(m_btnCloudAutoLabelAll, &QPushButton::clicked, this, [this](){
+        if (m_landingBusy || (m_cloudLabeler && m_cloudLabeler->isBusy())) return;
         if (m_modelCombo->currentIndex() == ProviderLandingAI) landingAIAutoLabelAll();
         else                                                    cloudAutoLabelAll();
     });
@@ -1311,9 +1313,9 @@ void MainWindow::cancelAutoLabel()
         m_activeLandingReply->abort();  // stop upload on the wire, not just in the callback
         m_activeLandingReply = nullptr;
     }
-    m_cloudLabeler->cancel();
     m_landingCancelled = true;
     m_landingQueue.clear();
+    m_cloudLabeler->cancel();
     resetCloudButtons();  // always reset — busyChanged may not fire when CloudAutoLabeler is already idle
 }
 
@@ -1456,7 +1458,9 @@ void MainWindow::submitLandingAIJob()
     ui->label_image->saveState();
 
     m_batchLandingApiKey = m_landingApiKey;  // snapshot — cannot change mid-request
-    m_batchLandingPrompt = m_cloudPrompt;
+    // Snapshot effective prompt at request start; when user-set prompt is empty,
+    // class names from m_objList are used — snapshot prevents mid-batch class file changes.
+    m_batchLandingPrompt = m_cloudPrompt.isEmpty() ? m_objList.join(" ; ") : m_cloudPrompt;
     m_landingCancelled = false;
     m_landingBusy = true;
     int gen = ++m_landingGeneration;
@@ -1497,10 +1501,7 @@ void MainWindow::doLandingAIJob(const QString &imagePath, int retryCount, int ge
     imgPart.setBodyDevice(imgFile);
     multiPart->append(imgPart);
 
-    QString effectivePrompt = m_batchLandingPrompt.isEmpty()
-        ? m_objList.join(" ; ")
-        : m_batchLandingPrompt;
-    for (const QString &p : effectivePrompt.split(";")) {
+    for (const QString &p : m_batchLandingPrompt.split(";")) {
         const QString label = p.trimmed();
         if (label.isEmpty()) continue;
         QHttpPart promptsPart;
@@ -1680,7 +1681,9 @@ void MainWindow::landingAIAutoLabelAll()
     ui->label_image->saveState();  // enable Ctrl+Z undo after batch labels are applied
 
     m_batchLandingApiKey = m_landingApiKey;  // snapshot — cannot change mid-batch
-    m_batchLandingPrompt = m_cloudPrompt;
+    // Snapshot effective prompt at batch start; when user-set prompt is empty,
+    // class names from m_objList are used — snapshot prevents mid-batch class file changes.
+    m_batchLandingPrompt = m_cloudPrompt.isEmpty() ? m_objList.join(" ; ") : m_cloudPrompt;
     m_landingCancelled = false;
     m_landingBusy = true;
     ++m_landingGeneration;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1307,6 +1307,10 @@ void MainWindow::resetCloudButtons()
 void MainWindow::cancelAutoLabel()
 {
     ++m_landingGeneration;  // invalidate any in-flight Landing AI callbacks
+    if (m_activeLandingReply) {
+        m_activeLandingReply->abort();  // stop upload on the wire, not just in the callback
+        m_activeLandingReply = nullptr;
+    }
     m_cloudLabeler->cancel();
     m_landingCancelled = true;
     m_landingQueue.clear();
@@ -1451,6 +1455,8 @@ void MainWindow::submitLandingAIJob()
     save_label_data();
     ui->label_image->saveState();
 
+    m_batchLandingApiKey = m_landingApiKey;  // snapshot — cannot change mid-request
+    m_batchLandingPrompt = m_cloudPrompt;
     m_landingCancelled = false;
     m_landingBusy = true;
     int gen = ++m_landingGeneration;
@@ -1491,9 +1497,9 @@ void MainWindow::doLandingAIJob(const QString &imagePath, int retryCount, int ge
     imgPart.setBodyDevice(imgFile);
     multiPart->append(imgPart);
 
-    QString effectivePrompt = m_cloudPrompt.isEmpty()
+    QString effectivePrompt = m_batchLandingPrompt.isEmpty()
         ? m_objList.join(" ; ")
-        : m_cloudPrompt;
+        : m_batchLandingPrompt;
     for (const QString &p : effectivePrompt.split(";")) {
         const QString label = p.trimmed();
         if (label.isEmpty()) continue;
@@ -1511,13 +1517,15 @@ void MainWindow::doLandingAIJob(const QString &imagePath, int retryCount, int ge
     multiPart->append(modelPart);
 
     QNetworkRequest req(QUrl(QString::fromLatin1(LANDING_AI_ENDPOINT)));
-    req.setRawHeader("Authorization", "Bearer " + m_landingApiKey.toUtf8());
+    req.setRawHeader("Authorization", "Bearer " + m_batchLandingApiKey.toUtf8());
     req.setTransferTimeout(30000);
 
     QNetworkReply *reply = m_landingNet->post(req, multiPart);
     multiPart->setParent(reply);
+    m_activeLandingReply = reply;
 
     connect(reply, &QNetworkReply::finished, this, [this, reply, imagePath, retryCount, gen]() {
+        m_activeLandingReply = nullptr;
         reply->deleteLater();
 
         // Discard stale callbacks (e.g. after cancel + re-submit)
@@ -1592,50 +1600,9 @@ void MainWindow::doLandingAIJob(const QString &imagePath, int retryCount, int ge
 
         // Collect valid detections before touching the file — only write if non-empty
         // (consistent with the "no detections" path above, which preserves the file).
-        QStringList outputLines;
         QStringList skippedLabels;
-        for (const QJsonValue &v : detections) {
-            if (!v.isObject()) continue;
-            QJsonObject obj = v.toObject();
-            QString label   = obj.value("label").toString();
-
-            int classId = m_objList.indexOf(label);
-            if (classId < 0) {
-                // Case-insensitive fallback
-                for (int i = 0; i < m_objList.size(); ++i) {
-                    if (m_objList[i].compare(label, Qt::CaseInsensitive) == 0) {
-                        classId = i; break;
-                    }
-                }
-            }
-            if (classId < 0) {
-                if (!label.isEmpty() && !skippedLabels.contains(label))
-                    skippedLabels << label;
-                continue;
-            }
-
-            QJsonArray bb = obj.value("bounding_box").toArray();
-            if (bb.size() < 4) continue;
-            if (!bb[0].isDouble() || !bb[1].isDouble() ||
-                !bb[2].isDouble() || !bb[3].isDouble()) continue;
-            double x1 = bb[0].toDouble(), y1 = bb[1].toDouble();
-            double x2 = bb[2].toDouble(), y2 = bb[3].toDouble();
-
-            double cx = ((x1 + x2) / 2.0) / imgW;
-            double cy = ((y1 + y2) / 2.0) / imgH;
-            double nw = (x2 - x1) / imgW;
-            double nh = (y2 - y1) / imgH;
-
-            if (cx < 0.0 || cx > 1.0 || cy < 0.0 || cy > 1.0 ||
-                nw <= 0.0 || nw > 1.0 || nh <= 0.0 || nh > 1.0) continue;
-
-            outputLines << QString("%1 %2 %3 %4 %5")
-                .arg(classId)
-                .arg(QString::number(cx, 'f', 6))
-                .arg(QString::number(cy, 'f', 6))
-                .arg(QString::number(nw, 'f', 6))
-                .arg(QString::number(nh, 'f', 6));
-        }
+        QStringList outputLines = CloudAutoLabeler::parseLandingAIDetections(
+            detections, m_objList, imgW, imgH, &skippedLabels);
 
         if (!outputLines.isEmpty()) {
             QString labelPath = QFileInfo(imagePath).dir().filePath(
@@ -1670,6 +1637,7 @@ void MainWindow::doLandingAIJob(const QString &imagePath, int retryCount, int ge
         }
     });
 }
+
 
 void MainWindow::landingAIAutoLabelAll()
 {
@@ -1711,6 +1679,8 @@ void MainWindow::landingAIAutoLabelAll()
     save_label_data();
     ui->label_image->saveState();  // enable Ctrl+Z undo after batch labels are applied
 
+    m_batchLandingApiKey = m_landingApiKey;  // snapshot — cannot change mid-batch
+    m_batchLandingPrompt = m_cloudPrompt;
     m_landingCancelled = false;
     m_landingBusy = true;
     ++m_landingGeneration;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -283,6 +283,8 @@ void MainWindow::set_args(int argc, char *argv[])
 
 void MainWindow::on_pushButton_open_files_clicked()
 {
+    if ((m_cloudLabeler && m_cloudLabeler->isBusy()) || m_landingBusy) return;
+
     bool bRetImgDir     = false;
     open_img_dir(bRetImgDir);
 
@@ -471,6 +473,8 @@ void MainWindow::clear_label_data()
 
 void MainWindow::remove_img()
 {
+    if ((m_cloudLabeler && m_cloudLabeler->isBusy()) || m_landingBusy) return;
+
     if(m_imgList.size() > 0) {
         //remove a image
         QFile::remove(m_imgList.at(m_imgIndex));
@@ -1649,18 +1653,19 @@ void MainWindow::doLandingAIJob(const QString &imagePath, int retryCount, int ge
             }
         }
 
-        if (!skippedLabels.isEmpty()) {
-            statusBar()->showMessage(
-                QString("Landing AI: detections skipped (unknown labels: %1)")
-                    .arg(skippedLabels.join(", ")), 5000);
-        }
-
         if (m_landingQueue.isEmpty()) {
             goto_img(m_imgIndex);
-            statusBar()->showMessage(
-                QString("Landing AI: %1 detection(s)").arg(outputLines.size()), 4000);
+            QString msg = QString("Landing AI: %1 detection(s)").arg(outputLines.size());
+            if (!skippedLabels.isEmpty())
+                msg += QString(" — skipped unknown labels: %1").arg(skippedLabels.join(", "));
+            statusBar()->showMessage(msg, 5000);
             resetCloudButtons();
         } else {
+            if (!skippedLabels.isEmpty()) {
+                statusBar()->showMessage(
+                    QString("Landing AI: detections skipped (unknown labels: %1)")
+                        .arg(skippedLabels.join(", ")), 5000);
+            }
             landingAIProcessNextInQueue();
         }
     });

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1306,6 +1306,7 @@ void MainWindow::cancelAutoLabel()
     m_cloudLabeler->cancel();
     m_landingCancelled = true;
     m_landingQueue.clear();
+    resetCloudButtons();  // always reset — busyChanged may not fire when CloudAutoLabeler is already idle
 }
 
 // ── Cloud auto-label ────────────────────────────────────────────────────────
@@ -1464,8 +1465,6 @@ void MainWindow::doLandingAIJob(const QString &imagePath, int retryCount, int ge
         return;
     }
 
-    static constexpr int MAX_LANDING_RETRIES = 3;
-
     auto *multiPart = new QHttpMultiPart(QHttpMultiPart::FormDataType);
 
     // Stream image via setBodyDevice() to avoid redundant in-memory copy.
@@ -1578,6 +1577,14 @@ void MainWindow::doLandingAIJob(const QString &imagePath, int retryCount, int ge
             imgSize = QImage(imagePath).size();
         double imgW = imgSize.width();
         double imgH = imgSize.height();
+
+        if (imgW <= 0 || imgH <= 0) {
+            statusBar()->showMessage(
+                "Landing AI: could not read image dimensions: " + imagePath, 5000);
+            if (m_landingQueue.isEmpty()) resetCloudButtons();
+            else                          landingAIProcessNextInQueue();
+            return;
+        }
 
         // Collect valid detections before touching the file — only write if non-empty
         // (consistent with the "no detections" path above, which preserves the file).

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -532,7 +532,7 @@ void MainWindow::load_label_list_data(QString qstrLabelListFile)
         {
             int nRow = ui->tableWidget_label->rowCount();
   
-            QString qstrLabel   = QString().fromStdString(strLabel);
+            QString qstrLabel   = QString().fromStdString(strLabel).trimmed();
             QColor  labelColor  = label_img::BOX_COLORS[(fileIndex++)%10];
             m_objList << qstrLabel;
 
@@ -1618,6 +1618,11 @@ void MainWindow::doLandingAIJob(const QString &imagePath, int retryCount, int ge
             } else {
                 statusBar()->showMessage(
                     "Landing AI: could not write label file: " + labelPath, 5000);
+                if (m_landingQueue.isEmpty())
+                    resetCloudButtons();
+                else
+                    landingAIProcessNextInQueue();
+                return;
             }
         }
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -9,6 +9,7 @@
 #include <QLabel>
 #include <QPushButton>
 #include <QSlider>
+#include <QComboBox>
 #include <QLineEdit>
 #include <QTabWidget>
 
@@ -110,6 +111,19 @@ private:
     QPushButton       *m_btnCloudAutoLabel;
     QPushButton       *m_btnCloudAutoLabelAll;
     QPushButton       *m_btnCancelAutoLabel;
+
+    // ── Landing AI ────────────────────────────────────────────────────
+    void submitLandingAIJob();
+    void doLandingAIJob(const QString &imagePath);
+    void landingAIAutoLabelAll();
+    void landingAIProcessNextInQueue();
+
+    QNetworkAccessManager *m_landingNet;
+    QString      m_landingApiKey;
+    QList<int>   m_landingQueue;
+    QString      m_landingPendingImagePath;
+    QComboBox   *m_modelCombo;
+    // ──────────────────────────────────────────────────────────────────
 
     QString    m_cloudApiKey;
     QString    m_cloudPrompt;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -11,6 +11,7 @@
 #include <QSlider>
 #include <QComboBox>
 #include <QLineEdit>
+#include <QNetworkAccessManager>
 #include <QTabWidget>
 
 #include "label_img.h"
@@ -113,8 +114,10 @@ private:
     QPushButton       *m_btnCancelAutoLabel;
 
     // ── Landing AI ────────────────────────────────────────────────────
+    enum CloudProvider { ProviderYoloLabel = 0, ProviderLandingAI = 1 };
+
     void submitLandingAIJob();
-    void doLandingAIJob(const QString &imagePath, int retryCount = 0);
+    void doLandingAIJob(const QString &imagePath, int retryCount, int gen);
     void landingAIAutoLabelAll();
     void landingAIProcessNextInQueue();
     bool checkLandingConsent();
@@ -122,7 +125,9 @@ private:
     QNetworkAccessManager *m_landingNet;
     QString      m_landingApiKey;
     QList<int>   m_landingQueue;
-    bool         m_landingCancelled = false;
+    bool         m_landingCancelled  = false;
+    bool         m_landingBusy       = false;
+    int          m_landingGeneration = 0;
     QComboBox   *m_modelCombo;
     // ──────────────────────────────────────────────────────────────────
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -114,14 +114,15 @@ private:
 
     // ── Landing AI ────────────────────────────────────────────────────
     void submitLandingAIJob();
-    void doLandingAIJob(const QString &imagePath);
+    void doLandingAIJob(const QString &imagePath, int retryCount = 0);
     void landingAIAutoLabelAll();
     void landingAIProcessNextInQueue();
+    bool checkLandingConsent();
 
     QNetworkAccessManager *m_landingNet;
     QString      m_landingApiKey;
     QList<int>   m_landingQueue;
-    QString      m_landingPendingImagePath;
+    bool         m_landingCancelled = false;
     QComboBox   *m_modelCombo;
     // ──────────────────────────────────────────────────────────────────
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -134,6 +134,7 @@ private:
     bool         m_landingCancelled  = false;
     bool         m_landingBusy       = false;
     int          m_landingGeneration = 0;
+    int          m_landingFailCount  = 0;
     QComboBox   *m_modelCombo;
     // ──────────────────────────────────────────────────────────────────
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -12,6 +12,7 @@
 #include <QComboBox>
 #include <QLineEdit>
 #include <QNetworkAccessManager>
+#include <QNetworkReply>
 #include <QTabWidget>
 
 #include "label_img.h"
@@ -125,7 +126,10 @@ private:
     static constexpr int MAX_LANDING_RETRIES = 3;
 
     QNetworkAccessManager *m_landingNet;
+    QNetworkReply         *m_activeLandingReply = nullptr;
     QString      m_landingApiKey;
+    QString      m_batchLandingApiKey;
+    QString      m_batchLandingPrompt;
     QList<int>   m_landingQueue;
     bool         m_landingCancelled  = false;
     bool         m_landingBusy       = false;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -122,6 +122,8 @@ private:
     void landingAIProcessNextInQueue();
     bool checkLandingConsent();
 
+    static constexpr int MAX_LANDING_RETRIES = 3;
+
     QNetworkAccessManager *m_landingNet;
     QString      m_landingApiKey;
     QList<int>   m_landingQueue;

--- a/tests/test_landing_ai_parser.cpp
+++ b/tests/test_landing_ai_parser.cpp
@@ -114,12 +114,25 @@ private slots:
 
     void outOfRangeCoordinates_skipped()
     {
-        // Box entirely outside image bounds → cx/cy/nw/nh fail the [0,1] guard
+        // Box entirely outside image bounds → all corners clamp to edge → zero size → skipped
         QJsonArray dets;
         dets << makeDetection("cat", 300, 300, 600, 600);  // image is 200x200
         QStringList lines = CloudAutoLabeler::parseLandingAIDetections(
             dets, {"cat"}, 200.0, 200.0);
         QVERIFY(lines.isEmpty());
+    }
+
+    void partiallyOffImageBox_clamped()
+    {
+        // Box extends beyond image edge on left → corners are clamped, valid box emitted
+        // x1=-10 → 0, y1=10 → 10, x2=90 → 90, y2=90 → 90 in 100x100 image
+        // cx=(0+90)/2/100=0.45, cy=(10+90)/2/100=0.5, nw=90/100=0.9, nh=80/100=0.8
+        QJsonArray dets;
+        dets << makeDetection("cat", -10, 10, 90, 90);
+        QStringList lines = CloudAutoLabeler::parseLandingAIDetections(
+            dets, {"cat"}, 100.0, 100.0);
+        QCOMPARE(lines.size(), 1);
+        QCOMPARE(lines[0], QString("0 0.450000 0.500000 0.900000 0.800000"));
     }
 
     void zeroSizeBox_skipped()

--- a/tests/test_landing_ai_parser.cpp
+++ b/tests/test_landing_ai_parser.cpp
@@ -1,0 +1,186 @@
+#include <QtTest>
+#include <QJsonArray>
+#include <QJsonObject>
+#include "cloud_labeler.h"
+
+// Helpers to build a minimal detection JSON object
+static QJsonObject makeDetection(const QString &label,
+                                  double x1, double y1, double x2, double y2)
+{
+    QJsonArray bb;
+    bb << x1 << y1 << x2 << y2;
+    QJsonObject obj;
+    obj["label"]        = label;
+    obj["bounding_box"] = bb;
+    return obj;
+}
+
+class TestLandingAIParser : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    // ── basic detection ───────────────────────────────────────────────────────
+    void singleDetection_exactMatch()
+    {
+        QJsonArray dets;
+        dets << makeDetection("cat", 100, 50, 300, 250);  // 200x200 px box in 400x400 image
+        QStringList lines = CloudAutoLabeler::parseLandingAIDetections(
+            dets, {"cat", "dog"}, 400.0, 400.0);
+        QCOMPARE(lines.size(), 1);
+        // cx=(100+300)/2/400=0.5, cy=(50+250)/2/400=0.375, nw=200/400=0.5, nh=200/400=0.5
+        QCOMPARE(lines[0], QString("0 0.500000 0.375000 0.500000 0.500000"));
+    }
+
+    void singleDetection_caseInsensitiveFallback()
+    {
+        QJsonArray dets;
+        dets << makeDetection("CAT", 0, 0, 100, 100);
+        QStringList lines = CloudAutoLabeler::parseLandingAIDetections(
+            dets, {"cat", "dog"}, 200.0, 200.0);
+        QCOMPARE(lines.size(), 1);
+        QVERIFY(lines[0].startsWith("0 "));
+    }
+
+    // ── unknown label ─────────────────────────────────────────────────────────
+    void unknownLabel_skipped()
+    {
+        QJsonArray dets;
+        dets << makeDetection("elephant", 0, 0, 50, 50);
+        QStringList skipped;
+        QStringList lines = CloudAutoLabeler::parseLandingAIDetections(
+            dets, {"cat", "dog"}, 100.0, 100.0, &skipped);
+        QVERIFY(lines.isEmpty());
+        QCOMPARE(skipped, QStringList{"elephant"});
+    }
+
+    void unknownLabel_notDuplicatedInSkipped()
+    {
+        QJsonArray dets;
+        dets << makeDetection("elephant", 0, 0, 10, 10);
+        dets << makeDetection("elephant", 20, 20, 30, 30);
+        QStringList skipped;
+        CloudAutoLabeler::parseLandingAIDetections(
+            dets, {"cat"}, 100.0, 100.0, &skipped);
+        QCOMPARE(skipped.size(), 1);
+    }
+
+    void emptyLabel_notAddedToSkipped()
+    {
+        QJsonArray dets;
+        dets << makeDetection("", 0, 0, 10, 10);
+        QStringList skipped;
+        CloudAutoLabeler::parseLandingAIDetections(
+            dets, {"cat"}, 100.0, 100.0, &skipped);
+        QVERIFY(skipped.isEmpty());
+    }
+
+    // ── bounding box validation ───────────────────────────────────────────────
+    void missingBoundingBox_skipped()
+    {
+        QJsonObject obj;
+        obj["label"] = "cat";
+        // no bounding_box key
+        QJsonArray dets;
+        dets << obj;
+        QStringList lines = CloudAutoLabeler::parseLandingAIDetections(
+            dets, {"cat"}, 100.0, 100.0);
+        QVERIFY(lines.isEmpty());
+    }
+
+    void shortBoundingBox_skipped()
+    {
+        QJsonObject obj;
+        obj["label"] = "cat";
+        obj["bounding_box"] = QJsonArray{10.0, 20.0};  // only 2 values
+        QJsonArray dets;
+        dets << obj;
+        QStringList lines = CloudAutoLabeler::parseLandingAIDetections(
+            dets, {"cat"}, 100.0, 100.0);
+        QVERIFY(lines.isEmpty());
+    }
+
+    void nonNumericBoundingBox_skipped()
+    {
+        QJsonObject obj;
+        obj["label"] = "cat";
+        obj["bounding_box"] = QJsonArray{QString("bad"), 0.0, 100.0, 100.0};
+        QJsonArray dets;
+        dets << obj;
+        QStringList lines = CloudAutoLabeler::parseLandingAIDetections(
+            dets, {"cat"}, 200.0, 200.0);
+        QVERIFY(lines.isEmpty());
+    }
+
+    void outOfRangeCoordinates_skipped()
+    {
+        // Box entirely outside image bounds → cx/cy/nw/nh fail the [0,1] guard
+        QJsonArray dets;
+        dets << makeDetection("cat", 300, 300, 600, 600);  // image is 200x200
+        QStringList lines = CloudAutoLabeler::parseLandingAIDetections(
+            dets, {"cat"}, 200.0, 200.0);
+        QVERIFY(lines.isEmpty());
+    }
+
+    void zeroSizeBox_skipped()
+    {
+        // nw and nh would be 0, which fails nw <= 0.0 guard
+        QJsonArray dets;
+        dets << makeDetection("cat", 50, 50, 50, 50);
+        QStringList lines = CloudAutoLabeler::parseLandingAIDetections(
+            dets, {"cat"}, 200.0, 200.0);
+        QVERIFY(lines.isEmpty());
+    }
+
+    // ── multiple detections, mixed validity ───────────────────────────────────
+    void multipleDetections_onlyValidEmitted()
+    {
+        QJsonArray dets;
+        dets << makeDetection("cat", 0, 0, 100, 100);     // valid
+        dets << makeDetection("ghost", 0, 0, 50, 50);     // unknown label
+        dets << makeDetection("dog", 200, 0, 400, 200);   // valid, class 1
+        QStringList skipped;
+        QStringList lines = CloudAutoLabeler::parseLandingAIDetections(
+            dets, {"cat", "dog"}, 400.0, 400.0, &skipped);
+        QCOMPARE(lines.size(), 2);
+        QVERIFY(lines[0].startsWith("0 "));
+        QVERIFY(lines[1].startsWith("1 "));
+        QCOMPARE(skipped, QStringList{"ghost"});
+    }
+
+    void emptyDetectionArray_returnsEmpty()
+    {
+        QStringList lines = CloudAutoLabeler::parseLandingAIDetections(
+            QJsonArray{}, {"cat"}, 100.0, 100.0);
+        QVERIFY(lines.isEmpty());
+    }
+
+    void nonObjectElement_ignored()
+    {
+        QJsonArray dets;
+        dets << QJsonValue(42);              // not an object
+        dets << makeDetection("cat", 0, 0, 50, 50);
+        QStringList lines = CloudAutoLabeler::parseLandingAIDetections(
+            dets, {"cat"}, 100.0, 100.0);
+        QCOMPARE(lines.size(), 1);
+    }
+
+    // ── coordinate math ───────────────────────────────────────────────────────
+    void coordinateMath_correctNormalization()
+    {
+        // Box: x1=100, y1=200, x2=300, y2=600 in 1000x1000 image
+        // cx = (100+300)/2 / 1000 = 0.2
+        // cy = (200+600)/2 / 1000 = 0.4
+        // nw = (300-100) / 1000 = 0.2
+        // nh = (600-200) / 1000 = 0.4
+        QJsonArray dets;
+        dets << makeDetection("cat", 100, 200, 300, 600);
+        QStringList lines = CloudAutoLabeler::parseLandingAIDetections(
+            dets, {"cat"}, 1000.0, 1000.0);
+        QCOMPARE(lines.size(), 1);
+        QCOMPARE(lines[0], QString("0 0.200000 0.400000 0.200000 0.400000"));
+    }
+};
+
+QTEST_MAIN(TestLandingAIParser)
+#include "test_landing_ai_parser.moc"

--- a/tests/test_landing_ai_parser.cpp
+++ b/tests/test_landing_ai_parser.cpp
@@ -148,6 +148,27 @@ private slots:
         QCOMPARE(skipped, QStringList{"ghost"});
     }
 
+    void crlfObjList_matchesTrimmed()
+    {
+        // objList entries with CRLF (Windows-formatted class file) must still match
+        QJsonArray dets;
+        dets << makeDetection("cat", 0, 0, 50, 50);
+        QStringList lines = CloudAutoLabeler::parseLandingAIDetections(
+            dets, {"cat\r", "dog\r"}, 100.0, 100.0);
+        QCOMPARE(lines.size(), 1);
+        QVERIFY(lines[0].startsWith("0 "));
+    }
+
+    void trailingSpaceLabel_matchesTrimmed()
+    {
+        QJsonArray dets;
+        dets << makeDetection("dog", 0, 0, 50, 50);
+        QStringList lines = CloudAutoLabeler::parseLandingAIDetections(
+            dets, {"cat", "dog  "}, 100.0, 100.0);
+        QCOMPARE(lines.size(), 1);
+        QVERIFY(lines[0].startsWith("1 "));
+    }
+
     void emptyDetectionArray_returnsEmpty()
     {
         QStringList lines = CloudAutoLabeler::parseLandingAIDetections(

--- a/tests/test_landing_ai_parser.pro
+++ b/tests/test_landing_ai_parser.pro
@@ -1,0 +1,8 @@
+QT += core network testlib
+QT -= gui
+CONFIG += c++17 console testcase
+CONFIG -= app_bundle
+DEFINES += UNIT_TEST
+SOURCES += test_landing_ai_parser.cpp ../cloud_labeler.cpp
+HEADERS += ../cloud_labeler.h
+INCLUDEPATH += ..


### PR DESCRIPTION
## Summary

Extends the cloud auto-label feature with a second provider: [Landing AI](https://landing-ai.com). Users can select the model from a combo box in the AI Settings tab.

> **Depends on PR #128** (feat: add cloud auto-label via yololabel.com), which is now merged into master. This branch is rebased on top of current master.

## Key changes (delta over #128)

- **Model combo** in the AI Settings tab: `YoloLabel AI` (default) and `Landing AI`
- `syncAiSettingsTab()` and `saveAiSettings()` switch between providers' keys based on selection; Landing AI key stored as `"landingApiKey"` in QSettings
- `checkLandingConsent()` — one-time privacy notice before images are uploaded to `api.va.landing.ai` (separate from the yololabel.com consent)
- `submitLandingAIJob()`, `doLandingAIJob()`, `landingAIAutoLabelAll()`, `landingAIProcessNextInQueue()` — full single-image and all-images flows
- Cancel button shown for both single and batch Landing AI operations; `cancelAutoLabel()` sets `m_landingCancelled` and clears the queue
- Retry logic: up to 3 retries on network failure (matching `CloudAutoLabeler::MAX_RETRIES`)
- `CloudAutoLabeler::mimeForImage()` reused for PNG/BMP/TIFF/WebP/JPEG Content-Type
- `CloudAutoLabeler::backupLabelFile()` called before overwriting any label file
- `save_label_data()` + `ui->label_image->saveState()` called before labeling so Ctrl+Z undo works
- **`QImageReader.size()`** used to get image dimensions without decoding pixels; falls back to `QImage` only if size query fails
- Full JSON validation: `data[0]` checked as array, `bounding_box` values checked as numeric, coordinates validated in `[0,1]` range
- Progress counter shows `done/total` where done = completed images (in-flight not counted as done)

## Test plan

- [ ] Select "Landing AI" from the model combo — privacy notice appears on first use only
- [ ] Enter a Landing AI API key, click Save; switch back to YoloLabel AI — key field shows the yololabel.com key
- [ ] Click "Auto Label AI" → verify detections and label file written correctly; Ctrl+Z undoes
- [ ] Click "Auto Label All AI" → verify progress counter and labels for all images; Cancel stops the run
- [ ] Submit with empty key → verify prompt to enter key in AI Settings tab
- [ ] Simulate network error → verify retry message and eventual error dialog after 3 tries

🤖 Generated with [Claude Code](https://claude.com/claude-code)