### PR TITLE
feat: Add global and per-class bounding box visibility toggles with filtering

### DIFF
--- a/label_img.cpp
+++ b/label_img.cpp
@@ -201,7 +201,7 @@ void label_img::init()
     m_bDragPending                  = false;
     m_dragBoxIdx                    = -1;
     m_focusedObjectLabel            = 0;
-    m_bVisualizeClassName           = true;
+    m_bVisualizeClassName           = false;
     m_bVisualizeBoundedBoxes        = true;
     m_zoomFactor                    = 1.0;
     m_panOffset                     = QPointF(0.0, 0.0);
@@ -524,6 +524,24 @@ void label_img::clearAllBoxes()
 {
     saveState();
     m_objBoundingBoxes.clear();
+}
+
+void label_img::clearVisibleBoxes()
+{
+    bool removedAny = false;
+
+    for (int i = m_objBoundingBoxes.size() - 1; i >= 0; --i)
+    {
+        if (!shouldDrawObject(m_objBoundingBoxes.at(i).label)) continue;
+
+        if (!removedAny)
+        {
+            saveState();
+            removedAny = true;
+        }
+
+        m_objBoundingBoxes.removeAt(i);
+    }
 }
 
 void label_img::saveState()

--- a/label_img.cpp
+++ b/label_img.cpp
@@ -201,6 +201,8 @@ void label_img::init()
     m_bDragPending                  = false;
     m_dragBoxIdx                    = -1;
     m_focusedObjectLabel            = 0;
+    m_bVisualizeClassName           = true;
+    m_bVisualizeBoundedBoxes        = true;
     m_zoomFactor                    = 1.0;
     m_panOffset                     = QPointF(0.0, 0.0);
     m_bPanning                      = false;
@@ -306,21 +308,24 @@ void label_img::showImage()
     gammaTransform(img);
 
     QPainter painter(&img);
-    QFont font = painter.font();
-    int fontSize = 16, xMargin = 5, yMargin = 2;
-    font.setPixelSize(fontSize);
-    font.setBold(true);
-    painter.setFont(font);
+    if (m_bVisualizeBoundedBoxes)
+    {
+        QFont font = painter.font();
+        int fontSize = 16, xMargin = 5, yMargin = 2;
+        font.setPixelSize(fontSize);
+        font.setBold(true);
+        painter.setFont(font);
 
-    int penThick = 3;
+        int penThick = 3;
 
-    QColor crossLineColor(255, 187, 0);
+        QColor crossLineColor(255, 187, 0);
 
-    drawCrossLine(painter, crossLineColor, penThick);
-    drawFocusedObjectBox(painter, Qt::magenta, penThick);
-    drawObjectBoxes(painter, penThick);
-    if(m_bVisualizeClassName)
-        drawObjectLabels(painter, penThick, fontSize, xMargin, yMargin);
+        drawCrossLine(painter, crossLineColor, penThick);
+        drawFocusedObjectBox(painter, Qt::magenta, penThick);
+        drawObjectBoxes(painter, penThick);
+        if(m_bVisualizeClassName)
+            drawObjectLabels(painter, penThick, fontSize, xMargin, yMargin);
+    }
 
     this->setPixmap(QPixmap::fromImage(img));
 }
@@ -401,7 +406,7 @@ void label_img::drawCrossLine(QPainter& painter, QColor color, int thickWidth)
 
 void label_img::drawFocusedObjectBox(QPainter& painter, Qt::GlobalColor color, int thickWidth)
 {
-    if(m_bLabelingStarted == true)
+    if(m_bLabelingStarted == true && shouldDrawObject(m_focusedObjectLabel))
     {
         QPen pen;
         pen.setWidth(thickWidth);
@@ -425,6 +430,8 @@ void label_img::drawObjectBoxes(QPainter& painter, int thickWidth)
 
     for(ObjectLabelingBox boundingbox: m_objBoundingBoxes)
     {
+        if (!shouldDrawObject(boundingbox.label)) continue;
+
         pen.setColor(m_drawObjectBoxColor.at(boundingbox.label));
         painter.setPen(pen);
 
@@ -439,6 +446,8 @@ void label_img::drawObjectLabels(QPainter& painter, int thickWidth, int fontPixe
 
     for(ObjectLabelingBox boundingbox: m_objBoundingBoxes)
     {
+        if (!shouldDrawObject(boundingbox.label)) continue;
+
         QColor labelColor = m_drawObjectBoxColor.at(boundingbox.label);
         QRect rectUi = cvtRelativeToAbsoluteRectInUi(boundingbox.box);
 
@@ -489,6 +498,7 @@ bool label_img::removeFocusedObjectBox(QPointF point)
     for(int i = 0; i < m_objBoundingBoxes.size(); i++)
     {
         QRectF objBox = m_objBoundingBoxes.at(i).box;
+        if (!shouldDrawObject(m_objBoundingBoxes.at(i).label)) continue;
 
         if(objBox.contains(point))
         {
@@ -556,6 +566,8 @@ int label_img::findBoxUnderCursor(QPointF point) const
     for(int i = 0; i < m_objBoundingBoxes.size(); i++)
     {
         QRectF objBox = m_objBoundingBoxes.at(i).box;
+        if (!shouldDrawObject(m_objBoundingBoxes.at(i).label)) continue;
+
         if(objBox.contains(point))
         {
             double distance = objBox.width() + objBox.height();
@@ -727,6 +739,40 @@ void label_img::resetZoom()
     m_zoomFactor = 1.0;
     m_panOffset = QPointF(0.0, 0.0);
     showImage();
+}
+
+void label_img::setVisualizeBoundedBoxes(bool visible)
+{
+    m_bVisualizeBoundedBoxes = visible;
+    showImage();
+}
+
+void label_img::resetClassVisibility()
+{
+    m_classVisibility.fill(true, m_objList.size());
+}
+
+void label_img::setClassVisible(int label, bool visible)
+{
+    if (label < 0) return;
+    if (m_classVisibility.size() < m_objList.size()) m_classVisibility.fill(true, m_objList.size());
+    if (label >= m_classVisibility.size()) m_classVisibility.resize(label + 1);
+
+    m_classVisibility[label] = visible;
+    showImage();
+}
+
+bool label_img::isClassVisible(int label) const
+{
+    if (label < 0) return false;
+    if (label >= m_classVisibility.size()) return true;
+
+    return m_classVisibility.at(label);
+}
+
+bool label_img::shouldDrawObject(int label) const
+{
+    return m_bVisualizeBoundedBoxes && isClassVisible(label);
 }
 
 void label_img::clampPanOffset()

--- a/label_img.h
+++ b/label_img.h
@@ -37,10 +37,12 @@ public:
 
     bool m_bLabelingStarted;
     bool m_bVisualizeClassName;
+    bool m_bVisualizeBoundedBoxes;
 
     static  QColor BOX_COLORS[10];
 
     QVector <ObjectLabelingBox>     m_objBoundingBoxes;
+    QVector <bool>                  m_classVisibility;
 
     void init();
     void openImage(const QString &, bool& ret);
@@ -50,10 +52,15 @@ public:
 
     void setFocusObjectLabel(int);
     void setContrastGamma(float);
+    void setVisualizeBoundedBoxes(bool visible);
+    void resetClassVisibility();
+    void setClassVisible(int label, bool visible);
+    bool isClassVisible(int label) const;
 
     bool isOpened();
 
     void clearAllBoxes();
+    void clearVisibleBoxes();
     void saveState();
     bool undo();
     bool redo();
@@ -119,6 +126,7 @@ private:
     void drawObjectBoxes(QPainter& , int thickWidth = 3);
     void drawObjectLabels(QPainter& , int thickWidth = 3, int fontPixelSize = 14, int xMargin = 5, int yMargin = 2);
     void gammaTransform(QImage& image);
+    bool shouldDrawObject(int label) const;
     bool removeFocusedObjectBox(QPointF);
 
 protected:

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -39,6 +39,7 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(new QShortcut(QKeySequence(Qt::Key_Space), this), &QShortcut::activated, this, [this]() { next_img(); });
     connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_D), this), &QShortcut::activated, this, &MainWindow::remove_img);
     connect(new QShortcut(QKeySequence(Qt::Key_Delete), this), &QShortcut::activated, this, &MainWindow::remove_img);
+
     connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_C), this), &QShortcut::activated, this, &MainWindow::copy_annotations);
     connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_V), this), &QShortcut::activated, this, &MainWindow::paste_annotations);
     connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_0), this), &QShortcut::activated, this, &MainWindow::reset_zoom);
@@ -517,8 +518,18 @@ void MainWindow::load_label_list_data(QString qstrLabelListFile)
 
 void MainWindow::populate_label_table()
 {
+    QSettings s("YoloLabel", "Session");
+    QStringList hiddenClassNames = s.value("hiddenClassNames").toStringList();
+    bool visualizeBoundedBoxes = s.value("visualizeBoundedBoxes", true).toBool();
+
+    ui->checkBox_visualize_bounded_boxes->blockSignals(true);
+    ui->checkBox_visualize_bounded_boxes->setChecked(visualizeBoundedBoxes);
+    ui->checkBox_visualize_bounded_boxes->blockSignals(false);
+    ui->label_image->setVisualizeBoundedBoxes(visualizeBoundedBoxes);
+
     ui->tableWidget_label->setRowCount(0);
     ui->label_image->m_drawObjectBoxColor.clear();
+    ui->tableWidget_label->blockSignals(true);
 
     for (int i = 0; i < m_objList.size(); ++i) {
         int nRow = ui->tableWidget_label->rowCount();
@@ -529,18 +540,28 @@ void MainWindow::populate_label_table()
         ui->tableWidget_label->insertRow(nRow);
 
         QTableWidgetItem *nameItem = new QTableWidgetItem(qstrLabel);
-        nameItem->setFlags(nameItem->flags() ^ Qt::ItemIsEditable);
+        nameItem->setFlags(nameItem->flags() | Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
+        nameItem->setFlags(nameItem->flags() & ~Qt::ItemIsEditable);
+        nameItem->setCheckState(hiddenClassNames.contains(qstrLabel) ? Qt::Unchecked : Qt::Checked);
         ui->tableWidget_label->setItem(nRow, 0, nameItem);
 
         QTableWidgetItem *colorItem = new QTableWidgetItem(QString());
         colorItem->setBackground(labelColor);
-        colorItem->setFlags(colorItem->flags() ^ Qt::ItemIsEditable ^ Qt::ItemIsSelectable);
+        colorItem->setFlags(colorItem->flags() & ~Qt::ItemIsEditable & ~Qt::ItemIsSelectable);
         ui->tableWidget_label->setItem(nRow, 1, colorItem);
 
         ui->label_image->m_drawObjectBoxColor.push_back(labelColor);
     }
     
     ui->label_image->m_objList = m_objList;
+    ui->label_image->resetClassVisibility();
+    for (int row = 0; row < ui->tableWidget_label->rowCount(); ++row)
+    {
+        QTableWidgetItem *nameItem = ui->tableWidget_label->item(row, 0);
+        if (!nameItem) continue;
+        ui->label_image->setClassVisible(row, nameItem->checkState() == Qt::Checked);
+    }
+    ui->tableWidget_label->blockSignals(false);
 }
 
 QString MainWindow::get_labeling_data(QString qstrImgFile)const

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -30,6 +30,7 @@ MainWindow::MainWindow(QWidget *parent) :
 
     connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_S), this), &QShortcut::activated, this, &MainWindow::save_label_data);
     connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_Delete), this), &QShortcut::activated, this, &MainWindow::clear_label_data);
+    connect(new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_Backspace), this), &QShortcut::activated, this, &MainWindow::clear_label_data);
 
     connect(new QShortcut(QKeySequence(Qt::Key_S), this), &QShortcut::activated, this, &MainWindow::next_label);
     connect(new QShortcut(QKeySequence(Qt::Key_W), this), &QShortcut::activated, this, &MainWindow::prev_label);
@@ -459,7 +460,8 @@ void MainWindow::save_label_data()
 
 void MainWindow::clear_label_data()
 {
-    ui->label_image->clearAllBoxes();
+    // ui->label_image->clearAllBoxes();
+    ui->label_image->clearVisibleBoxes();
     ui->label_image->showImage();
 }
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -45,8 +45,11 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->checkBox_visualize_class_name->setStyleSheet(
         "QCheckBox { color: rgb(0, 255, 255); }"
         "QCheckBox::indicator { width: 18px; height: 18px; border: 2px solid rgb(0, 255, 255); background-color: white; border-radius: 3px; }"
-        "QCheckBox::indicator:checked { background-color: rgb(0, 255, 255); }"
-    );
+        "QCheckBox::indicator:checked { background-color: rgb(0, 255, 255); }");
+    ui->checkBox_visualize_bounded_boxes->setStyleSheet(
+        "QCheckBox { color: rgb(0, 255, 255); }"
+        "QCheckBox::indicator { width: 18px; height: 18px; border: 2px solid rgb(0, 255, 255); background-color: white; border-radius: 3px; }"
+        "QCheckBox::indicator:checked { background-color: rgb(0, 255, 255); }");
 
     m_usageTimerElapsedSeconds = 0;
     m_usageTimer = new QTimer(this);
@@ -305,11 +308,22 @@ void MainWindow::saveSession()
     QSettings s("YoloLabel", "Session");
     s.setValue("imgDir",  m_imgDir);
     s.setValue("objFile", m_objFilePath);
+    s.setValue("visualizeBoundedBoxes", ui->checkBox_visualize_bounded_boxes->isChecked());
 
     QStringList colors;
     for (const QColor &c : ui->label_image->m_drawObjectBoxColor)
         colors << c.name();
     s.setValue("classColors", colors);
+
+    QStringList hiddenClassNames;
+    for (int row = 0; row < ui->tableWidget_label->rowCount(); ++row)
+    {
+        QTableWidgetItem *nameItem = ui->tableWidget_label->item(row, 0);
+        if (!nameItem || nameItem->checkState() == Qt::Checked)
+            continue;
+        hiddenClassNames << nameItem->text();
+    }
+    s.setValue("hiddenClassNames", hiddenClassNames);
 }
 
 void MainWindow::restoreLastSession()
@@ -492,37 +506,39 @@ void MainWindow::load_label_list_data(QString qstrLabelListFile)
 
     if(inputLabelListFile.is_open())
     {
-        for(int i = 0 ; i <= ui->tableWidget_label->rowCount(); i++)
-            ui->tableWidget_label->removeRow(ui->tableWidget_label->currentRow());
-
         m_objList.clear();
-
-        ui->tableWidget_label->setRowCount(0);
-        ui->label_image->m_drawObjectBoxColor.clear();
-
         string strLabel;
-        int fileIndex = 0;
-        while(getline(inputLabelListFile, strLabel))
-        {
-            int nRow = ui->tableWidget_label->rowCount();
-  
-            QString qstrLabel   = QString().fromStdString(strLabel);
-            QColor  labelColor  = label_img::BOX_COLORS[(fileIndex++)%10];
-            m_objList << qstrLabel;
-
-            ui->tableWidget_label->insertRow(nRow);
-
-            ui->tableWidget_label->setItem(nRow, 0, new QTableWidgetItem(qstrLabel));
-            ui->tableWidget_label->item(nRow, 0)->setFlags(ui->tableWidget_label->item(nRow, 0)->flags() ^  Qt::ItemIsEditable);
-
-            ui->tableWidget_label->setItem(nRow, 1, new QTableWidgetItem(QString().fromStdString("")));
-            ui->tableWidget_label->item(nRow, 1)->setBackground(labelColor);
-            ui->tableWidget_label->item(nRow, 1)->setFlags(ui->tableWidget_label->item(nRow, 1)->flags() ^  Qt::ItemIsEditable ^  Qt::ItemIsSelectable);
-
-            ui->label_image->m_drawObjectBoxColor.push_back(labelColor);
-        }
-        ui->label_image->m_objList = m_objList;
+        while(getline(inputLabelListFile, strLabel)) m_objList << QString::fromStdString(strLabel);
+        populate_label_table();
     }
+}
+
+void MainWindow::populate_label_table()
+{
+    ui->tableWidget_label->setRowCount(0);
+    ui->label_image->m_drawObjectBoxColor.clear();
+
+    for (int i = 0; i < m_objList.size(); ++i) {
+        int nRow = ui->tableWidget_label->rowCount();
+        QString qstrLabel = m_objList.at(i);
+        
+        QColor labelColor = label_img::BOX_COLORS[i % 10];
+
+        ui->tableWidget_label->insertRow(nRow);
+
+        QTableWidgetItem *nameItem = new QTableWidgetItem(qstrLabel);
+        nameItem->setFlags(nameItem->flags() ^ Qt::ItemIsEditable);
+        ui->tableWidget_label->setItem(nRow, 0, nameItem);
+
+        QTableWidgetItem *colorItem = new QTableWidgetItem(QString());
+        colorItem->setBackground(labelColor);
+        colorItem->setFlags(colorItem->flags() ^ Qt::ItemIsEditable ^ Qt::ItemIsSelectable);
+        ui->tableWidget_label->setItem(nRow, 1, colorItem);
+
+        ui->label_image->m_drawObjectBoxColor.push_back(labelColor);
+    }
+    
+    ui->label_image->m_objList = m_objList;
 }
 
 QString MainWindow::get_labeling_data(QString qstrImgFile)const
@@ -804,6 +820,21 @@ void MainWindow::on_checkBox_visualize_class_name_clicked(bool checked)
 {
     ui->label_image->m_bVisualizeClassName = checked;
     ui->label_image->showImage();
+    saveSession();
+}
+
+void MainWindow::on_checkBox_visualize_bounded_boxes_clicked(bool checked)
+{
+    ui->label_image->setVisualizeBoundedBoxes(checked);
+    saveSession();
+}
+
+void MainWindow::on_tableWidget_label_itemChanged(QTableWidgetItem *item)
+{
+    if (!item || item->column() != 0) return;
+
+    ui->label_image->setClassVisible(item->row(), item->checkState() == Qt::Checked);
+    saveSession();
 }
 
 void MainWindow::copy_annotations()
@@ -956,34 +987,9 @@ void MainWindow::loadClassesFromModel()
     const auto& classNames = m_detector.getClassNames();
     if (classNames.empty()) return;
 
-    // Clear existing table
-    while (ui->tableWidget_label->rowCount() > 0)
-        ui->tableWidget_label->removeRow(0);
-
     m_objList.clear();
-    ui->label_image->m_drawObjectBoxColor.clear();
-
-    // Populate from model metadata (same pattern as load_label_list_data)
-    int fileIndex = 0;
-    for (const auto& pair : classNames) {
-        int nRow = ui->tableWidget_label->rowCount();
-        QString qstrLabel = QString::fromStdString(pair.second);
-        QColor labelColor = label_img::BOX_COLORS[(fileIndex++) % 10];
-        m_objList << qstrLabel;
-
-        ui->tableWidget_label->insertRow(nRow);
-        ui->tableWidget_label->setItem(nRow, 0, new QTableWidgetItem(qstrLabel));
-        ui->tableWidget_label->item(nRow, 0)->setFlags(
-            ui->tableWidget_label->item(nRow, 0)->flags() ^ Qt::ItemIsEditable);
-
-        ui->tableWidget_label->setItem(nRow, 1, new QTableWidgetItem(QString()));
-        ui->tableWidget_label->item(nRow, 1)->setBackground(labelColor);
-        ui->tableWidget_label->item(nRow, 1)->setFlags(
-            ui->tableWidget_label->item(nRow, 1)->flags() ^ Qt::ItemIsEditable ^ Qt::ItemIsSelectable);
-
-        ui->label_image->m_drawObjectBoxColor.push_back(labelColor);
-    }
-    ui->label_image->m_objList = m_objList;
+    for (const auto& pair : classNames) m_objList << QString::fromStdString(pair.second);
+    populate_label_table();
 
     if (!m_objList.isEmpty()) {
         set_label(0);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -56,7 +56,10 @@ private slots:
 
     void on_horizontalSlider_contrast_sliderMoved(int value);
 
+    void on_checkBox_visualize_bounded_boxes_clicked(bool checked);
     void on_checkBox_visualize_class_name_clicked(bool checked);
+
+    void on_tableWidget_label_itemChanged(QTableWidgetItem *item);
 
     void copy_annotations();
     void paste_annotations();
@@ -82,6 +85,7 @@ private:
     void            goto_img(const int);
 
     void            load_label_list_data(QString);
+    void            populate_label_table();
     QString         get_labeling_data(QString)const;
 
     void            set_label(const int);

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -107,7 +107,7 @@ border-color: rgb(0, 255, 255);}
            <number>3</number>
           </property>
           <property name="text">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open a Dataset Directory...&lt;/p&gt;&lt;p&gt;D: Next Image&lt;/p&gt;&lt;p&gt;A: Prev Image&lt;/p&gt;&lt;p&gt;S: Next Class&lt;/p&gt;&lt;p&gt;W: Prev Class&lt;/p&gt;&lt;p&gt;V: Visualize Class Name&lt;/p&gt;&lt;p&gt;O: Open Files&lt;br/&gt;Ctrl + S: Save&lt;/p&gt;&lt;p&gt;Ctrl + D: Delete an Image&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open a Dataset Directory...&lt;/p&gt;&lt;p&gt;D: Next Image&lt;/p&gt;&lt;p&gt;A: Prev Image&lt;/p&gt;&lt;p&gt;S: Next Class&lt;/p&gt;&lt;p&gt;W: Prev Class&lt;/p&gt;&lt;p&gt;B: Visualize Bounded Boxes&lt;/p&gt;&lt;p&gt;V: Visualize Class Name&lt;/p&gt;&lt;p&gt;O: Open Files&lt;br/&gt;Ctrl + S: Save&lt;/p&gt;&lt;p&gt;Ctrl + D: Delete an Image&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="scaledContents">
            <bool>true</bool>
@@ -600,6 +600,31 @@ QTableWidget::item:selected {
         </property>
        </widget>
       </item>
+            <item>
+             <widget class="QCheckBox" name="checkBox_visualize_bounded_boxes">
+                <property name="font">
+                 <font>
+                    <family>Arial</family>
+                    <pointsize>12</pointsize>
+                    <underline>false</underline>
+                    <strikeout>false</strikeout>
+                 </font>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true">color : rgb(0, 255, 255);
+</string>
+                </property>
+                <property name="text">
+                 <string>Visualize Bounded Boxes</string>
+                </property>
+                <property name="shortcut">
+                 <string>B</string>
+                </property>
+             </widget>
+            </item>
      </layout>
     </item>
    </layout>


### PR DESCRIPTION
## Summary
When labeling complex datasets, users often encounter cluttered images with numerous overlapping bounding boxes. Additionally, reviewing or refining a single, poorly predicted class from pseudo-labeling can be tedious when all other classes are displayed.

This Pull Request introduces a comprehensive visualization filtering system, allowing users to toggle the visibility of all bounding boxes globally or filter specific classes individually. It also ensures that core actions (like clearing data) respect these visibility filters.

## Key Features

* **Global Bounding Box Toggle:** Added a "Visualize Bounded Boxes" checkbox next to the existing class name toggle. It can be triggered via the `B` keyboard shortcut to completely hide/show all bounding boxes, making it easy to inspect the raw image.
* **Per-Class Visibility Toggles:** Integrated checkmarks into each row of the classes table widget on the right. Users can now check/uncheck individual classes to isolate them for focused review or adjustment.
* **Visibility-Aware Actions:** Destructive or bulk operations now respect the visibility filtering. For example, using `Ctrl + Delete` or `Ctrl + Backspace` will only delete visible boxes, leaving hidden classes untouched.

## Other
* **Checkbox Startup Bugfix:** Resolved a UI desynchronization bug where the "Visualize Class Name" checkbox started visually unchecked on startup despite class names being drawn on screen (which previously required two clicks to sync).
* **Alternative Shortcut:** Added `Ctrl + Backspace` as an alternative shortcut alongside `Ctrl + Delete` for clearing label data, resolving shortcut collision issues.
* **New Shortcut:** Pressing `B` hides/shows all bounding boxes.
